### PR TITLE
Moved dashboard to /app endpoint

### DIFF
--- a/static/client/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/static/client/components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,7 +9,7 @@ const Breadcrumbs = () => {
   const [breadcrumbs, setBreadcrumbs] = useState<IBreadcrumb[]>([]);
 
   useEffect(() => {
-    const pageIndex = location.pathname.indexOf("webpage/");
+    const pageIndex = location.pathname.indexOf("app/webpage/");
     if (pageIndex > 0) {
       const parts = location.pathname.substring(pageIndex + 8).split("/");
       if (parts.length) {
@@ -18,7 +18,7 @@ const Breadcrumbs = () => {
           accumulatedPath = `${accumulatedPath}/${part}`;
           return {
             name: part,
-            link: `/webpage${accumulatedPath}`,
+            link: `app/webpage${accumulatedPath}`,
           };
         });
         setBreadcrumbs(paths);

--- a/static/client/components/MainLayout/MainLayout.test.tsx
+++ b/static/client/components/MainLayout/MainLayout.test.tsx
@@ -9,7 +9,7 @@ describe("MainLayout", () => {
     const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={["/"]} key="testkey">
+        <MemoryRouter initialEntries={["/app"]} key="testkey">
           <MainLayout />
         </MemoryRouter>
       </QueryClientProvider>,

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -26,7 +26,7 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
           </div>
           <hr />
           <div className="row">
-            {location.pathname === "/" && (
+            {location.pathname === "/app" && (
               <>
                 <h2>Welcome to the Content System</h2>
                 <h3 className="p-heading--4">Please select a page that you are looking for from the left sidebar</h3>

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -19,7 +19,7 @@ const Navigation = (): JSX.Element => {
   }, []);
 
   const handleNewPageClick = useCallback(() => {
-    navigate("/new-webpage");
+    navigate("/app/new-webpage");
   }, [navigate]);
 
   return (

--- a/static/client/components/Navigation/NavigationItems/NavigationItems.tsx
+++ b/static/client/components/Navigation/NavigationItems/NavigationItems.tsx
@@ -20,7 +20,7 @@ const NavigationItems = ({ onSelectPage }: INavigationItemsProps): React.ReactNo
       if (onSelectPage) {
         onSelectPage(path);
       } else {
-        if (selectedProject) navigate(`/webpage/${selectedProject.name}${path}`);
+        if (selectedProject) navigate(`/app/webpage/${selectedProject.name}${path}`);
       }
     },
     [selectedProject, onSelectPage, navigate],
@@ -29,7 +29,7 @@ const NavigationItems = ({ onSelectPage }: INavigationItemsProps): React.ReactNo
   // set active page whenever the location changes
   useEffect(() => {
     const parts = location.pathname.split("/");
-    if (parts.length > 3 && parts[1] === "webpage") {
+    if (parts.length > 4 && parts[2] === "webpage") {
       const path = `/${parts.slice(3).join("/")}`;
       setActivePageName(path);
     } else {

--- a/static/client/components/Search/Search.tsx
+++ b/static/client/components/Search/Search.tsx
@@ -40,7 +40,7 @@ const Search = (): JSX.Element => {
         const project = SearchServices.getProjectByName(data, selectedItem.project);
         if (project) setSelectedProject(project);
       }
-      navigate(`/webpage/${selectedItem.project}${selectedItem.name}`);
+      navigate(`/app/webpage/${selectedItem.project}${selectedItem.name}`);
     },
     [data, navigate, searchRef, selectedProject, setSelectedProject],
   );

--- a/static/client/components/SiteSelector/SiteSelector.tsx
+++ b/static/client/components/SiteSelector/SiteSelector.tsx
@@ -19,7 +19,7 @@ const SiteSelector = (): JSX.Element | null => {
   useEffect(() => {
     if (projects.length && !selectedProject) {
       // get project name from URL
-      const match = location.pathname.match(/\/webpage\/([^/]+)/);
+      const match = location.pathname.match(/\/app\/webpage\/([^/]+)/);
       let projectFromURL;
       if (match) {
         projectFromURL = projects.find((p) => p.name === match[1]);

--- a/static/client/main.test.tsx
+++ b/static/client/main.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
+import { act } from "react";
+
 import { waitFor } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
 
 describe("main", () => {
   beforeAll(() => {

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -10,7 +10,7 @@ const Main = (): React.ReactNode => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<MainLayout />} path="/" />
+        <Route element={<MainLayout />} path="/app" />
         {data?.length &&
           data.map(
             (project) =>

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import MainLayout from "@/components/MainLayout";
 import { usePages } from "@/services/api/hooks/pages";
@@ -10,7 +10,8 @@ const Main = (): React.ReactNode => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<MainLayout />} path="/" />
+        <Route element={<MainLayout />} path="/app" />
+        <Route element={<Navigate to="/app" />} path="/" />
         {data?.length &&
           data.map(
             (project) =>

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -10,7 +10,7 @@ const Main = (): React.ReactNode => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<MainLayout />} path="/app" />
+        <Route element={<MainLayout />} path="/" />
         {data?.length &&
           data.map(
             (project) =>

--- a/static/client/services/routes/index.tsx
+++ b/static/client/services/routes/index.tsx
@@ -17,7 +17,7 @@ export function generateRoutes(project: string, pages: IPage[]): JSX.Element[] {
           </MainLayout>
         }
         key={page.name}
-        path={`/webpage/${project}${page.name}`}
+        path={`/app/webpage/${project}${page.name}`}
       />
       <Route
         element={
@@ -26,7 +26,7 @@ export function generateRoutes(project: string, pages: IPage[]): JSX.Element[] {
           </MainLayout>
         }
         key="new-webpage"
-        path="/new-webpage"
+        path="/app/new-webpage"
       />
       {page.children?.length && generateRoutes(project, page.children)}
     </React.Fragment>

--- a/templates/login.html
+++ b/templates/login.html
@@ -25,7 +25,7 @@
     aria-label="External link to Ubuntu One"
     href="https://login.ubuntu.com"><i class="p-icon--external-link"></i>Ubuntu One</a> account.
                 </p>
-                <a class="p-button--positive button" href="/login?next=/">Login with U1</a>
+                <a class="p-button--positive button" href="/login?next={{ next }}">Login with U1</a>
             </div>
         </div>
     </section>

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -79,9 +79,10 @@ def set_cache_control_headers(response):
     Default caching rules that should work for most pages
     """
 
-    if flask.request.path.startswith(
-        "/_status"
-    ) or flask.request.path.startswith("/"):
+    if (
+        flask.request.path.startswith("/_status")
+        or flask.request.path == "/app"
+    ):
         # Our status endpoints need to be uncached
         # to report accurate information at all times.
         # The base path is also uncached to ensure that we don't cache the base

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -16,8 +16,8 @@ app.register_blueprint(jira_blueprint)
 
 
 # Client-side routes
-@app.route("/")
-@app.route("/new-webpage")
+@app.route("/app")
+@app.route("/app/new-webpage")
 @login_required
 def index():
     return render_template(
@@ -25,7 +25,7 @@ def index():
     )
 
 
-@app.route("/webpage/<path:path>")
+@app.route("/app/webpage/<path:path>")
 @login_required
 def webpage(path):
     return render_template(

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -47,9 +47,11 @@ def init_sso(app: flask.Flask):
 
         return flask.redirect("/login_page")
 
+    @app.route("/")
     @app.route("/login_page")
     def login_page():
-        return flask.render_template("login.html")
+        next = flask.request.args.get("next", "/app")
+        return flask.render_template("login.html", next=next)
 
 
 def login_required(func):
@@ -71,6 +73,6 @@ def login_required(func):
         if "openid" in flask.session:
             return func(*args, **kwargs)
 
-        return flask.redirect("/login_page" + flask.request.path)
+        return flask.redirect("/login_page?next=" + flask.request.path)
 
     return is_user_logged_in

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -51,6 +51,8 @@ def init_sso(app: flask.Flask):
     @app.route("/login_page")
     def login_page():
         next = flask.request.args.get("next", "/app")
+        if "openid" in flask.session:
+            return flask.redirect(next)
         return flask.render_template("login.html", next=next)
 
 


### PR DESCRIPTION
## Done

 - Moved the app dashboard to /app. 

The content-cache has non-editable cache headers for the root path, which means our root path `/` should be cacheable. We _don't_ want the dashboard to be cachable, as it will retain invalid state briefly after logout.

In addition, if we keep the dashboard on the root path, `/`, it will be cached as the response after login, so any subsequent requests won't be authenticated. 

The dashboard code itself is served from an SPA whose url changes on each deployment, so it will be unaffected by this change, and can be cached as normal.

## QA

 - Open the demo, and if not logged in you should be redirected to the root path. If you try to open a restricted link e.g. `/app` you should be redirected to `/login_page`.
 - Logging in should redirect you to the path you made the request from e.g. if you were redirected from `/app/webpage`, the final location should be `/app/webpage`.
 - Logging out should redirect you to `/login_page`
