### PR TITLE
Fix ambiguous search results

### DIFF
--- a/static/client/components/Search/Search.tsx
+++ b/static/client/components/Search/Search.tsx
@@ -74,7 +74,7 @@ const Search = (): JSX.Element => {
           <ul className="l-search-dropdown">
             {matches.map((match) => (
               <li className="l-search-item" onClick={handleSelect(match)} onMouseDown={handleOptionMouseDown}>
-                {match.name} - {match.title}
+                {`${match.project}${match.name}`} {match.title && `- ${match.title}`}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Done

 - Show domain/project name along with page, in search results.

## QA steps

 - View the application in your browser at: https://cs-canonical-com-97.demos.haus/
 - Login using U1, if not already logged in.
 - Using searchbar at the top, search for web pages.
 - Verify the project name is visible in search results.

## Fixes

 - Fixes [WD-17634](https://warthogs.atlassian.net/browse/WD-17634)

## Screenshots
 - Before
![image](https://github.com/user-attachments/assets/af573010-b5a8-48cd-b030-797f54a2b4f7)


 - After
![image](https://github.com/user-attachments/assets/ae732174-ddc7-47b6-ab51-7dbf1c83d29b)



[WD-17633]: https://warthogs.atlassian.net/browse/WD-17633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-17634]: https://warthogs.atlassian.net/browse/WD-17634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ