### PR TITLE
WD-16245 Add tooltips to request types when creating a Jira request

### DIFF
--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -55,16 +55,3 @@
 .p-search-and-filter__search-container {
   height: auto !important;
 }
-
-// basic spacing/aligning utilities for flexbox
-.flex{
-  display: flex;
-}
-
-.items-baseline {
-  align-items: baseline;   
-}
-
-.gap-small {
-  gap: 0.3rem;
-}

--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -55,3 +55,16 @@
 .p-search-and-filter__search-container {
   height: auto !important;
 }
+
+// basic spacing/aligning utilities for flexbox
+.flex{
+  display: flex;
+}
+
+.items-baseline {
+  align-items: baseline;   
+}
+
+.gap-small {
+  gap: 0.3rem;
+}

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent, useCallback, useMemo, useState } from "react";
 
-import { Button, Input, Modal, RadioInput, Spinner, Textarea } from "@canonical/react-components";
+import { Button, Input, Modal, RadioInput, Spinner, Textarea, Tooltip } from "@canonical/react-components";
 
 import type { IRequestTaskModalProps } from "./RequestTaskModal.types";
 
@@ -117,50 +117,65 @@ const RequestTaskModal = ({
     >
       {[ChangeRequestType.COPY_UPDATE, ChangeRequestType.PAGE_REFRESH].indexOf(changeType) >= 0 && (
         <>
-          <div className="flex items-baseline gap-small">
+          <div className="u-sv2">
             <RadioInput
               checked={changeType === ChangeRequestType.COPY_UPDATE}
-              label="Copy update"
+              inline
+              label={
+                <>
+                  Copy update&nbsp;
+                  <Tooltip
+                    message={
+                      <ul className="u-no-margin">
+                        <li>Textual changes in existing sections of a webpage</li>
+                        <li>
+                          Adding a new section in an existing layout,
+                          <br />
+                          identical to an existing section in terms of design,
+                          <br />
+                          but with different textual content. <br />
+                          Or removing a section entirely.
+                        </li>
+                        <li>Replacing existing logos and images</li>
+                        <li>Removing an image or a logo</li>
+                      </ul>
+                    }
+                    zIndex={999}
+                  >
+                    <i className="p-icon--information" />
+                  </Tooltip>
+                </>
+              }
               onChange={handleTypeChange(ChangeRequestType.COPY_UPDATE)}
             />
-            <div aria-describedby="default-tooltip" className="p-tooltip">
-              <i className="p-icon--information" />
-              <div className="p-tooltip__message" id="default-tooltip" role="tooltip">
-                <ul className="u-no-margin--bottom">
-                  <li>Textual changes in existing sections of a webpage</li>
-                  <li>
-                    Adding a new section in an existing layout,
-                    <br />
-                    identical to an existing section in terms of design,
-                    <br />
-                    but with different textual content. Or removing a section entirely.
-                  </li>
-                  <li>Replacing existing logos and images</li>
-                  <li>removing an image or a logo</li>
-                </ul>
-              </div>
-            </div>
           </div>
-          <div className="flex items-baseline gap-small">
+          <div className="u-sv2">
             <RadioInput
               checked={changeType === ChangeRequestType.PAGE_REFRESH}
-              label="Page refresh"
+              inline
+              label={
+                <>
+                  Page refresh&nbsp;
+                  <Tooltip
+                    message={
+                      <ul className="u-no-margin">
+                        <li>
+                          Changing or adding to the existing layout,
+                          <br />
+                          this can be the whole page or just one section
+                        </li>
+                        <li>The new modification changes the existing layout</li>
+                        <li>Requires a UI and UX review</li>
+                      </ul>
+                    }
+                    zIndex={999}
+                  >
+                    <i className="p-icon--information" />
+                  </Tooltip>
+                </>
+              }
               onChange={handleTypeChange(ChangeRequestType.PAGE_REFRESH)}
             />
-            <div aria-describedby="default-tooltip" className="p-tooltip">
-              <i className="p-icon--information" />
-              <div className="p-tooltip__message" id="default-tooltip" role="tooltip">
-                <ul className="u-no-margin--bottom">
-                  <li>
-                    Changing or adding to the existing layout,
-                    <br />
-                    this can be the whole page or just one section
-                  </li>
-                  <li>The new modification changes the existing layout</li>
-                  <li>Requires a UI and UX review</li>
-                </ul>
-              </div>
-            </div>
           </div>
         </>
       )}

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -129,13 +129,11 @@ const RequestTaskModal = ({
                       <ul className="u-no-margin">
                         <li>Textual changes in existing sections of a webpage</li>
                         <li>
-                          Adding a new section in an existing layout,
+                          Adding a new section which reuses an existing
                           <br />
-                          identical to an existing section in terms of design,
-                          <br />
-                          but with different textual content. <br />
-                          Or removing a section entirely.
+                          layout on the page but with different textual content
                         </li>
+                        <li>Removing a section entirely</li>
                         <li>Replacing existing logos and images</li>
                         <li>Removing an image or a logo</li>
                       </ul>
@@ -165,7 +163,6 @@ const RequestTaskModal = ({
                           this can be the whole page or just one section
                         </li>
                         <li>The new modification changes the existing layout</li>
-                        <li>Requires a UI and UX review</li>
                       </ul>
                     }
                     zIndex={999}

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -117,16 +117,51 @@ const RequestTaskModal = ({
     >
       {[ChangeRequestType.COPY_UPDATE, ChangeRequestType.PAGE_REFRESH].indexOf(changeType) >= 0 && (
         <>
-          <RadioInput
-            checked={changeType === ChangeRequestType.COPY_UPDATE}
-            label="Copy update"
-            onClick={handleTypeChange(ChangeRequestType.COPY_UPDATE)}
-          />
-          <RadioInput
-            checked={changeType === ChangeRequestType.PAGE_REFRESH}
-            label="Page refresh"
-            onClick={handleTypeChange(ChangeRequestType.PAGE_REFRESH)}
-          />
+          <div className="flex items-baseline gap-small">
+            <RadioInput
+              checked={changeType === ChangeRequestType.COPY_UPDATE}
+              label="Copy update"
+              onClick={handleTypeChange(ChangeRequestType.COPY_UPDATE)}
+            />
+            <div aria-describedby="default-tooltip" className="p-tooltip">
+              <i className="p-icon--information" />
+              <div className="p-tooltip__message" id="default-tooltip" role="tooltip">
+                <ul className="u-no-margin--bottom">
+                  <li>Textual changes in existing sections of a webpage</li>
+                  <li>
+                    Adding a new section in an existing layout,
+                    <br />
+                    identical to an existing section in terms of design,
+                    <br />
+                    but with different textual content. Or removing a section entirely.
+                  </li>
+                  <li>Replacing existing logos and images</li>
+                  <li>removing an image or a logo</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-baseline gap-small">
+            <RadioInput
+              checked={changeType === ChangeRequestType.PAGE_REFRESH}
+              label="Page refresh"
+              onClick={handleTypeChange(ChangeRequestType.PAGE_REFRESH)}
+            />
+            <div aria-describedby="default-tooltip" className="p-tooltip">
+              <i className="p-icon--information" />
+              <div className="p-tooltip__message" id="default-tooltip" role="tooltip">
+                <ul className="u-no-margin--bottom">
+                  <li>
+                    Changing or adding to the existing layout,
+                    <br />
+                    this can be the whole page or just one section
+                  </li>
+                  <li>The new modification changes the existing layout</li>
+                  <li>Requires a UI and UX review</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </>
       )}
       <Input label="Due date" min={DatesServices.getNowStr()} onChange={handleChangeDueDate} required type="date" />

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -121,7 +121,7 @@ const RequestTaskModal = ({
             <RadioInput
               checked={changeType === ChangeRequestType.COPY_UPDATE}
               label="Copy update"
-              onClick={handleTypeChange(ChangeRequestType.COPY_UPDATE)}
+              onChange={handleTypeChange(ChangeRequestType.COPY_UPDATE)}
             />
             <div aria-describedby="default-tooltip" className="p-tooltip">
               <i className="p-icon--information" />
@@ -145,7 +145,7 @@ const RequestTaskModal = ({
             <RadioInput
               checked={changeType === ChangeRequestType.PAGE_REFRESH}
               label="Page refresh"
-              onClick={handleTypeChange(ChangeRequestType.PAGE_REFRESH)}
+              onChange={handleTypeChange(ChangeRequestType.PAGE_REFRESH)}
             />
             <div aria-describedby="default-tooltip" className="p-tooltip">
               <i className="p-icon--information" />


### PR DESCRIPTION
## Done

 - Add tooltips to request types when creating a Jira request.

## QA

 - Open the [Demo](https://cs-canonical-com-101.demos.haus/) in your browser.
 - Select any project from the sidebar, and open any page.
 - Click on the green `Request Changes` button and a modal will be displayed.
 - Verify the `information` icon next to radio buttons, and hover on each icon to see the tooltip telling more about each request type.

## Fixes

 - Fixes #[WD-16245](https://warthogs.atlassian.net/browse/WD-16245)


[WD-16245]: https://warthogs.atlassian.net/browse/WD-16245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ