### PR TITLE
feat: Update reviewers and owners for a page in real-time, without having to reload (WD-17983)

### DIFF
--- a/static/client/components/OwnerAndReviewers/Owner.tsx
+++ b/static/client/components/OwnerAndReviewers/Owner.tsx
@@ -28,8 +28,7 @@ const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element =>
     (option: IUser) => {
       if (page?.id) {
         PagesServices.setOwner(option, page.id).then(() => {
-          // reload the page for the new owner to appear in the pages tree
-          window.location.reload();
+          page.owner = option;
         });
       }
       setOptions([]);

--- a/static/client/components/OwnerAndReviewers/Reviewers.tsx
+++ b/static/client/components/OwnerAndReviewers/Reviewers.tsx
@@ -21,8 +21,7 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
       setCurrentReviewers(newReviewers);
       if (page?.id)
         PagesServices.setReviewers(newReviewers, page.id).then(() => {
-          // reload the page for the reviewer to be removed from the pages tree
-          window.location.reload();
+          page.reviewers = newReviewers;
         });
       if (onSelectReviewers) onSelectReviewers(newReviewers);
     },
@@ -37,8 +36,7 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
         const newReviewers = [...currentReviewers, option];
         if (page?.id) {
           PagesServices.setReviewers(newReviewers, page.id).then(() => {
-            // reload the page for the new reviewer to appear in the pages tree
-            window.location.reload();
+            page.reviewers = newReviewers;
           });
         }
         setOptions([]);


### PR DESCRIPTION
## Done

 - Update page owner and reviewers in real-time, without having to reload the webpage to update pages tree.

## QA

 - Open the [Demo](https://cs-canonical-com-103.demos.haus/) in your browser.
 - Select any project from the left sidebar, and open any page from the pages tree.
 - Update the owner for the web page. Select any other page from the pages tree and then come back to the previously modified page. The page should show the updated owner.
 - Update the reviews for the web page. Select any other page from the pages tree and then come back to the previously modified page. The page should show the updated reviewers.
 - All the modifications should remain visible without having to reload the webpage.

## Fixes

 - Fixes #[WD-17983](https://warthogs.atlassian.net/browse/WD-17983)

[WD-17983]: https://warthogs.atlassian.net/browse/WD-17983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ