### PR TITLE
Backend functionality for getting current logged in user's information from canonical directory, and storing it in users table upon login

### DIFF
--- a/webapp/routes/user.py
+++ b/webapp/routes/user.py
@@ -1,15 +1,13 @@
-from os import environ
-
-import requests
-from flask import jsonify, request, Blueprint, current_app
+from flask import jsonify, request, Blueprint, current_app, session
 
 from webapp.site_repository import SiteRepository
 from webapp.sso import login_required
 from webapp.tasks import LOCKS
-from webapp.helper import get_or_create_user_id
+from webapp.helper import get_or_create_user_id, get_user_from_directory_by_key
 from webapp.models import (
     Project,
     Reviewer,
+    User,
     Webpage,
     db,
     get_or_create,
@@ -21,32 +19,7 @@ user_blueprint = Blueprint("user", __name__, url_prefix="/api")
 @user_blueprint.route("/get-users/<username>", methods=["GET"])
 @login_required
 def get_users(username: str):
-    query = """
-    query($name: String!) {
-        employees(filter: { contains: { name: $name }}) {
-            id
-            name
-            email
-            team
-            department
-            jobTitle
-        }
-    }
-    """
-
-    headers = {"Authorization": "token " + environ.get("DIRECTORY_API_TOKEN")}
-
-    # Currently directory-api only supports strict comparison of field values,
-    # so we have to send two requests instead of one for first and last names
-    response = requests.post(
-        "https://directory.wpe.internal/graphql/",
-        json={
-            "query": query,
-            "variables": {"name": username.strip()},
-        },
-        headers=headers,
-        verify=False,
-    )
+    response = get_user_from_directory_by_key("name", username)
 
     if response.status_code == 200:
         users = response.json().get("data", {}).get("employees", [])
@@ -113,3 +86,27 @@ def set_owner():
         site_repository.invalidate_cache()
 
     return jsonify({"message": "Successfully set owner"}), 200
+
+
+@user_blueprint.route("/current-user", methods=["GET"])
+@login_required
+def current_user():
+    user_id = session["openid"]["user_id"]
+    if not user_id:
+        return jsonify({"error": "Currently logged in user not found"}), 404
+    user = User.query.filter_by(id=user_id).first()
+    if not user:
+        return jsonify({"error": "Currently logged in user not found"}), 404
+    return (
+        jsonify(
+            {
+                "id": user.id,
+                "name": user.name,
+                "email": user.email,
+                "team": user.team,
+                "department": user.department,
+                "jobTitle": user.job_title,
+            }
+        ),
+        200,
+    )


### PR DESCRIPTION
## Done

 - Checked the existence of logged in user in "users" table, and if negative, fetched user info from canonical directory and saved in users table
 - Stored user id in session
 - Added an endpoint `/api/current-user` to fetch currently logged in user's info
 - Added a helper function called `get_user_from_directory_by_key` which fetches a user from canonical directory by a given key,value.

## QA

### QA steps
Please note that you need to test it locally, because the directory API on demo is currently not working and is being fixed in a different task.
 - Check out this PR and run the application using `dotrun` command locally.
 - Open `localhost:8104` in your browser.
 - Log in using Ubuntu SSO if not already.
 - Make sure you have the VPN on. (This is required to fetch data from directory API)
 - Call the `localhost:8104/api/current-user` GET endpoint and verify it returns the currently logged in user's info.

## Fixes

 - Fixes #[WD-18146](https://warthogs.atlassian.net/browse/WD-18146)


[WD-18146]: https://warthogs.atlassian.net/browse/WD-18146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ