### PR TITLE
[WD-18147] Persist currently logged in user's info on the frontend and show in sidebar

### DIFF
--- a/static/client/App.tsx
+++ b/static/client/App.tsx
@@ -1,14 +1,12 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 
 import "./App.scss";
+import config from "./config";
 import Main from "./pages/Main";
 
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    },
+    queries: config.api.FETCH_OPTIONS,
   },
 });
 

--- a/static/client/App.tsx
+++ b/static/client/App.tsx
@@ -3,7 +3,14 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import "./App.scss";
 import Main from "./pages/Main";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  },
+});
 
 const App: React.FC = () => {
   return (

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -9,14 +9,12 @@ import NavigationItems from "./NavigationItems";
 
 import NavigationCollapseToggle from "@/components/Navigation/NavigationCollapseToggle";
 import SiteSelector from "@/components/SiteSelector";
-import { useAuth } from "@/services/api/hooks/auth";
 import { useStore } from "@/store";
 
 const Navigation = (): JSX.Element => {
   const navigate = useNavigate();
   const [isCollapsed, setIsCollapsed] = useState(true);
-  const setUser = useStore((state) => state.setUser);
-  const { data: user } = useAuth();
+  const [user, setUser] = useStore((state) => [state.user, state.setUser]);
 
   const logout = useCallback(() => {
     setUser(null);

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -60,10 +60,10 @@ const Navigation = (): JSX.Element => {
               <NavigationItems />
             </div>
             <div className="p-panel__footer p-side-navigation--icons">
-              <div className="u-no-margin u-truncate">
+              <div className="u-no-margin u-truncate p-side-navigation__label">
                 <span>{user?.name}</span>
               </div>
-              <div className="p-text--small u-text--muted u-truncate">
+              <div className="p-text--small u-text--muted u-truncate p-side-navigation__label">
                 <span>{user?.email}</span>
               </div>
               <hr className="p-rule" />

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -16,7 +16,7 @@ const Navigation = (): JSX.Element => {
   const navigate = useNavigate();
   const [isCollapsed, setIsCollapsed] = useState(true);
   const setUser = useStore((state) => state.setUser);
-  const { user } = useAuth();
+  const { data: user } = useAuth();
 
   const logout = useCallback(() => {
     setUser(null);

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -9,14 +9,19 @@ import NavigationItems from "./NavigationItems";
 
 import NavigationCollapseToggle from "@/components/Navigation/NavigationCollapseToggle";
 import SiteSelector from "@/components/SiteSelector";
+import { useAuth } from "@/services/api/hooks/auth";
+import { useStore } from "@/store";
 
 const Navigation = (): JSX.Element => {
   const navigate = useNavigate();
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const setUser = useStore((state) => state.setUser);
+  const { user } = useAuth();
 
   const logout = useCallback(() => {
+    setUser(null);
     window.open("/logout", "_self");
-  }, []);
+  }, [setUser]);
 
   const handleNewPageClick = useCallback(() => {
     navigate("/app/new-webpage");
@@ -55,6 +60,13 @@ const Navigation = (): JSX.Element => {
               <NavigationItems />
             </div>
             <div className="p-panel__footer p-side-navigation--icons">
+              <div className="u-no-margin u-truncate">
+                <span>{user?.name}</span>
+              </div>
+              <div className="p-text--small u-text--muted u-truncate">
+                <span>{user?.email}</span>
+              </div>
+              <hr className="p-rule" />
               <Button appearance="base" className="p-side-navigation__link" onClick={logout}>
                 <i className="p-icon--logout is-light p-side-navigation__icon" />
                 <span className="p-side-navigation__label">Log out</span>

--- a/static/client/components/Navigation/_Navigation.scss
+++ b/static/client/components/Navigation/_Navigation.scss
@@ -79,7 +79,7 @@
     }
 
     .p-panel__content {
-      height: calc(100vh - 340px);
+      height: calc(100vh - 440px);
       overflow: auto;
 
       @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -1,10 +1,12 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import MainLayout from "@/components/MainLayout";
+import { useAuth } from "@/services/api/hooks/auth";
 import { usePages } from "@/services/api/hooks/pages";
 import { RoutesServices } from "@/services/routes";
 
 const Main = (): React.ReactNode => {
+  useAuth();
   const { data } = usePages();
 
   return (

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -7,6 +7,7 @@ export const ENDPOINTS = {
   createNewPage: "/api/create-page",
   requestChanges: "/api/request-changes",
   requestRemoval: "/api/remove-webpage",
+  currentUser: "/api/current-user",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/hooks/auth.ts
+++ b/static/client/services/api/hooks/auth.ts
@@ -1,29 +1,26 @@
-import { useCallback } from "react";
-
 import { useQuery } from "react-query";
 
 import { getCurrentUser } from "@/services/api/services/users";
+import type { IApiBasicError, IUseQueryHookRest } from "@/services/api/types/query";
+import type { IUser } from "@/services/api/types/users";
 import { useStore } from "@/store";
 
-export function useAuth() {
-  const [user, setUser] = useStore((state) => [state.user, state.setUser]);
+export function useAuth(): IUseQueryHookRest<IUser> {
+  const [user, setUser] = useStore((state) => [state.user ?? undefined, state.setUser]);
 
-  const result = useQuery({
-    queryKey: "loggedInUser",
-    queryFn: () => {
-      getCurrentUser().then((res) => {
-        setUser(res);
-      });
-    },
+  const result = useQuery<IUser, IApiBasicError>("loggedInUser", async () => {
+    try {
+      const res = await getCurrentUser();
+      setUser(res);
+      return res;
+    } catch (error) {
+      throw new Error("Failed to fetch current user");
+    }
   });
-
-  const refetch = useCallback(() => {
-    return result.refetch();
-  }, [result]);
 
   const isLoading = result.isLoading;
   const isFetching = result.isFetching;
   const error = result.error;
 
-  return { isLoading, user, error, refetch, isFetching };
+  return { isLoading, data: user, error, isFetching };
 }

--- a/static/client/services/api/hooks/auth.ts
+++ b/static/client/services/api/hooks/auth.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+
+import { useQuery } from "react-query";
+
+import { getCurrentUser } from "@/services/api/services/users";
+import { useStore } from "@/store";
+
+export function useAuth() {
+  const [user, setUser] = useStore((state) => [state.user, state.setUser]);
+
+  const result = useQuery({
+    queryKey: "loggedInUser",
+    queryFn: () => {
+      getCurrentUser().then((res) => {
+        setUser(res);
+      });
+    },
+  });
+
+  const refetch = useCallback(() => {
+    return result.refetch();
+  }, [result]);
+
+  const isLoading = result.isLoading;
+  const isFetching = result.isFetching;
+  const error = result.error;
+
+  return { isLoading, user, error, refetch, isFetching };
+}

--- a/static/client/services/api/partials/UsersApiClass.ts
+++ b/static/client/services/api/partials/UsersApiClass.ts
@@ -1,10 +1,14 @@
 import { BasicApiClass } from "./BasicApiClass";
 
 import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
-import { type IUsersResponse } from "@/services/api/types/users";
+import type { IUser, IUsersResponse } from "@/services/api/types/users";
 
 export class UsersApiClass extends BasicApiClass {
   public getUsers(username: string): Promise<IUsersResponse> {
     return this.callApi<IUsersResponse>(ENDPOINTS.getUsers(username), REST_TYPES.GET);
+  }
+
+  public getCurrentUser(): Promise<IUser> {
+    return this.callApi<{ data: IUser }>(ENDPOINTS.currentUser, REST_TYPES.GET).then((res) => res.data);
   }
 }

--- a/static/client/services/api/services/users.ts
+++ b/static/client/services/api/services/users.ts
@@ -1,8 +1,12 @@
 import { api } from "@/services/api";
-import type { IUsersResponse } from "@/services/api/types/users";
+import type { IUser, IUsersResponse } from "@/services/api/types/users";
 
 export const getUsers = async (username: string): Promise<IUsersResponse> => {
   return api.users.getUsers(username);
+};
+
+export const getCurrentUser = async (): Promise<IUser> => {
+  return api.users.getCurrentUser();
 };
 
 export * as UsersServices from "./users";

--- a/static/client/store/types.ts
+++ b/static/client/store/types.ts
@@ -1,8 +1,9 @@
 import { type IPagesResponse } from "@/services/api/types/pages";
+import { type IUser } from "@/services/api/types/users";
 
 export interface IStore {
   selectedProject: IPagesResponse["data"] | null;
-  user: string | null;
+  user: IUser | null;
   setSelectedProject: (s: IPagesResponse["data"]) => void;
-  setUser: (u: string) => void;
+  setUser: (u: IUser | null) => void;
 }


### PR DESCRIPTION
## Done

 - Created a context to persist current user's info
 - Display logged in user's name and email in the sidebar
 - Setup query client provider
 - Call `/api/current-user` on app load.

## QA

### QA steps

 - Check out this PR 
 - Open the file `webapp/routes/user.py` to see if it has a `current-user` GET endpoint. If not, paste the following sample endpoint
 ```
@user_blueprint.route("/current-user", methods=["GET"])
@login_required
def current_user():
    return (
        jsonify(
            {
                "id": 1,
                "name": "Muhammad Ali",
                "email": "muhammad.ali@canonical.com",
                "team": "Web and Design",
                "department": "Engineering",
                "jobTitle": "Software Engineer I",
            }
        ),
        200,
    )
```
 - Run the application using dotrun command locally.
 - Open localhost:8104 in your browser.
 - Log in using Ubuntu SSO if not already.
 - Verify the user name and email visible in the left sidebar, on top of log out button.

## Fixes

 - Fixes #[WD-18147](https://warthogs.atlassian.net/browse/WD-18147)

## Screenshots
Before
![image](https://github.com/user-attachments/assets/0671ddb9-69b7-41fc-a568-c5402fd808be)

After
![image](https://github.com/user-attachments/assets/6bc09e1f-3bfe-4f83-b7ca-8ec6650d0ead)



[WD-18147]: https://warthogs.atlassian.net/browse/WD-18147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ