### PR TITLE
[WD-18202] fix: invalid prefix in breadcrumbs and links not working

### DIFF
--- a/static/client/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/static/client/components/Breadcrumbs/Breadcrumbs.tsx
@@ -11,14 +11,14 @@ const Breadcrumbs = () => {
   useEffect(() => {
     const pageIndex = location.pathname.indexOf("app/webpage/");
     if (pageIndex > 0) {
-      const parts = location.pathname.substring(pageIndex + 8).split("/");
+      const parts = location.pathname.split("app/webpage/")[1].split("/");
       if (parts.length) {
         let accumulatedPath = "";
         const paths = parts?.map((part) => {
           accumulatedPath = `${accumulatedPath}/${part}`;
           return {
             name: part,
-            link: `app/webpage${accumulatedPath}`,
+            link: `/app/webpage${accumulatedPath}`,
           };
         });
         setBreadcrumbs(paths);


### PR DESCRIPTION
## Done

 - Fix invalid prefix
 - Fix links not working

## QA

### QA steps

 - Open the [demo](https://cs-canonical-com-109.demos.haus/)
 - Login using SSO if not already logged in
 - Select any project and page from the left sidebar
 - Verify the breadcrumbs working properly

## Fixes

 - Fixes [WD-18202](https://warthogs.atlassian.net/browse/WD-18202)

## Screenshots
Before
![image](https://github.com/user-attachments/assets/70a55370-308c-4d79-acea-d8e655396701)


After
![image](https://github.com/user-attachments/assets/d2af582d-95cd-49b2-88ac-2ad2b7b80228)


[WD-18202]: https://warthogs.atlassian.net/browse/WD-18202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ