### PR TITLE
[WD-16243] Render, associate and update products with webpages

### DIFF
--- a/static/client/components/Common/CustomSearchAndFilter.tsx
+++ b/static/client/components/Common/CustomSearchAndFilter.tsx
@@ -1,8 +1,7 @@
 // the existing SearchAndFilter component provided by react-components did not provide ability to have dynamic options
 import { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 
-import type { ICustomSearchAndFilterProps } from "./OwnerAndReviewers.types";
-
+import type { ICustomSearchAndFilterProps } from "@/components/OwnerAndReviewers/OwnerAndReviewers.types";
 import type { IUser } from "@/services/api/types/users";
 
 const CustomSearchAndFilter = ({

--- a/static/client/components/OwnerAndReviewers/Owner.tsx
+++ b/static/client/components/OwnerAndReviewers/Owner.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 
-import CustomSearchAndFilter from "./CustomSearchAndFilter";
 import { useUsersRequest } from "./OwnerAndReviewers.hooks";
 import type { IOwnerAndReviewersProps } from "./OwnerAndReviewers.types";
 
+import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
 import { PagesServices } from "@/services/api/services/pages";
 import { type IUser } from "@/services/api/types/users";
 

--- a/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
+++ b/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
@@ -1,5 +1,7 @@
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 
+import type { MultiSelectItem } from "@canonical/react-components";
+
 import type { IPage } from "@/services/api/types/pages";
 import type { IUser } from "@/services/api/types/users";
 
@@ -28,4 +30,9 @@ export interface IUseUsersRequest {
 export interface IReporterProps {
   reporter: IUser | null;
   setReporter: React.Dispatch<React.SetStateAction<IUser>>;
+}
+
+export interface IProductsProps {
+  page?: IPage;
+  onSelectProducts?: (products: MultiSelectItem[]) => void;
 }

--- a/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
+++ b/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
@@ -1,7 +1,5 @@
 import type { ChangeEvent, Dispatch, SetStateAction } from "react";
 
-import type { MultiSelectItem } from "@canonical/react-components";
-
 import type { IPage } from "@/services/api/types/pages";
 import type { IUser } from "@/services/api/types/users";
 
@@ -25,14 +23,4 @@ export interface IUseUsersRequest {
   options: IUser[];
   setOptions: Dispatch<SetStateAction<IUser[]>>;
   handleChange: (event: ChangeEvent<HTMLInputElement>) => void;
-}
-
-export interface IReporterProps {
-  reporter: IUser | null;
-  setReporter: React.Dispatch<React.SetStateAction<IUser>>;
-}
-
-export interface IProductsProps {
-  page?: IPage;
-  onSelectProducts?: (products: MultiSelectItem[]) => void;
 }

--- a/static/client/components/OwnerAndReviewers/Products.tsx
+++ b/static/client/components/OwnerAndReviewers/Products.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { MultiSelectItem } from "@canonical/react-components";
+import { MultiSelect } from "@canonical/react-components";
+
+import type { IProductsProps } from "./OwnerAndReviewers.types";
+
+import { useProducts } from "@/services/api/hooks/products";
+import { PagesServices } from "@/services/api/services/pages";
+import type { ISetProducts } from "@/services/api/types/pages";
+
+const Products = ({ page, onSelectProducts }: IProductsProps): JSX.Element => {
+  const [products, setProducts] = useState<MultiSelectItem[]>([]);
+  const [selectedProducts, setSelectedProducts] = useState<MultiSelectItem[]>([]);
+  const { data } = useProducts();
+
+  useEffect(() => {
+    if (data?.data?.length) {
+      setProducts(
+        data.data.map((p) => ({
+          label: p.name,
+          value: p.id,
+        })),
+      );
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (page && page.products) {
+      setSelectedProducts(page.products.map((p) => ({ label: p.name, value: p.id })));
+    }
+  }, [page]);
+
+  const onItemsUpdate = useCallback(
+    (items: MultiSelectItem[]) => {
+      setSelectedProducts(items);
+      if (page?.id) {
+        PagesServices.setProducts({
+          webpage_id: page?.id,
+          product_ids: items.map((p) => p.value),
+        } as ISetProducts);
+      }
+      if (onSelectProducts) onSelectProducts(items);
+    },
+    [onSelectProducts, page?.id],
+  );
+
+  return products.length ? (
+    <>
+      <p className="p-text--small-caps" id="products-input">
+        Products
+      </p>
+      <MultiSelect
+        items={products}
+        onItemsUpdate={onItemsUpdate}
+        placeholder="Select products"
+        selectedItems={selectedProducts}
+        variant="condensed"
+      />
+    </>
+  ) : (
+    <></>
+  );
+};
+
+export default Products;

--- a/static/client/components/OwnerAndReviewers/Products.tsx
+++ b/static/client/components/OwnerAndReviewers/Products.tsx
@@ -8,6 +8,7 @@ import type { IProductsProps } from "./OwnerAndReviewers.types";
 import { useProducts } from "@/services/api/hooks/products";
 import { PagesServices } from "@/services/api/services/pages";
 import type { ISetProducts } from "@/services/api/types/pages";
+import { IProduct } from "@/services/api/types/products";
 
 const Products = ({ page, onSelectProducts }: IProductsProps): JSX.Element => {
   const [products, setProducts] = useState<MultiSelectItem[]>([]);
@@ -35,6 +36,7 @@ const Products = ({ page, onSelectProducts }: IProductsProps): JSX.Element => {
     (items: MultiSelectItem[]) => {
       setSelectedProducts(items);
       if (page?.id) {
+        page.products = items.map((p) => ({ name: p.label, id: p.value }) as IProduct);
         PagesServices.setProducts({
           webpage_id: page?.id,
           product_ids: items.map((p) => p.value),

--- a/static/client/components/OwnerAndReviewers/Reviewers.tsx
+++ b/static/client/components/OwnerAndReviewers/Reviewers.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 
-import CustomSearchAndFilter from "./CustomSearchAndFilter";
 import { useUsersRequest } from "./OwnerAndReviewers.hooks";
 import type { IOwnerAndReviewersProps } from "./OwnerAndReviewers.types";
 
+import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
 import { PagesServices } from "@/services/api/services/pages";
 import { type IUser } from "@/services/api/types/users";
 

--- a/static/client/components/Products/Products.tsx
+++ b/static/client/components/Products/Products.tsx
@@ -3,12 +3,11 @@ import { useCallback, useEffect, useState } from "react";
 import type { MultiSelectItem } from "@canonical/react-components";
 import { MultiSelect } from "@canonical/react-components";
 
-import type { IProductsProps } from "./OwnerAndReviewers.types";
-
+import type { IProductsProps } from "@/components/OwnerAndReviewers/OwnerAndReviewers.types";
 import { useProducts } from "@/services/api/hooks/products";
 import { PagesServices } from "@/services/api/services/pages";
 import type { ISetProducts } from "@/services/api/types/pages";
-import { IProduct } from "@/services/api/types/products";
+import type { IProduct } from "@/services/api/types/products";
 
 const Products = ({ page, onSelectProducts }: IProductsProps): JSX.Element => {
   const [products, setProducts] = useState<MultiSelectItem[]>([]);
@@ -44,7 +43,7 @@ const Products = ({ page, onSelectProducts }: IProductsProps): JSX.Element => {
       }
       if (onSelectProducts) onSelectProducts(items);
     },
-    [onSelectProducts, page?.id],
+    [onSelectProducts, page],
   );
 
   return products.length ? (

--- a/static/client/components/Products/Products.tsx
+++ b/static/client/components/Products/Products.tsx
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 import type { MultiSelectItem } from "@canonical/react-components";
 import { MultiSelect } from "@canonical/react-components";
 
-import type { IProductsProps } from "@/components/OwnerAndReviewers/OwnerAndReviewers.types";
+import type { IProductsProps } from "./Products.types";
+
 import { useProducts } from "@/services/api/hooks/products";
 import { PagesServices } from "@/services/api/services/pages";
 import type { ISetProducts } from "@/services/api/types/pages";

--- a/static/client/components/Products/Products.types.ts
+++ b/static/client/components/Products/Products.types.ts
@@ -1,0 +1,8 @@
+import type { MultiSelectItem } from "@canonical/react-components";
+
+import type { IPage } from "@/services/api/types/pages";
+
+export interface IProductsProps {
+  page?: IPage;
+  onSelectProducts?: (products: MultiSelectItem[]) => void;
+}

--- a/static/client/components/Products/index.ts
+++ b/static/client/components/Products/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Products";

--- a/static/client/components/Reporter/Reporter.tsx
+++ b/static/client/components/Reporter/Reporter.tsx
@@ -1,9 +1,8 @@
 import { useCallback } from "react";
 
-import CustomSearchAndFilter from "./CustomSearchAndFilter";
-import { useUsersRequest } from "./OwnerAndReviewers.hooks";
-import type { IReporterProps } from "./OwnerAndReviewers.types";
-
+import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
+import { useUsersRequest } from "@/components/OwnerAndReviewers/OwnerAndReviewers.hooks";
+import type { IReporterProps } from "@/components/OwnerAndReviewers/OwnerAndReviewers.types";
 import { type IUser } from "@/services/api/types/users";
 import { useStore } from "@/store";
 

--- a/static/client/components/Reporter/Reporter.tsx
+++ b/static/client/components/Reporter/Reporter.tsx
@@ -1,8 +1,9 @@
 import { useCallback } from "react";
 
+import type { IReporterProps } from "./Reporter.types";
+
 import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
 import { useUsersRequest } from "@/components/OwnerAndReviewers/OwnerAndReviewers.hooks";
-import type { IReporterProps } from "@/components/OwnerAndReviewers/OwnerAndReviewers.types";
 import { type IUser } from "@/services/api/types/users";
 import { useStore } from "@/store";
 

--- a/static/client/components/Reporter/Reporter.types.ts
+++ b/static/client/components/Reporter/Reporter.types.ts
@@ -1,0 +1,6 @@
+import type { IUser } from "@/services/api/types/users";
+
+export interface IReporterProps {
+  reporter: IUser | null;
+  setReporter: React.Dispatch<React.SetStateAction<IUser>>;
+}

--- a/static/client/components/Reporter/index.ts
+++ b/static/client/components/Reporter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Reporter";

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -4,7 +4,7 @@ import { Button, Input, Modal, RadioInput, Spinner, Textarea, Tooltip } from "@c
 
 import type { IRequestTaskModalProps } from "./RequestTaskModal.types";
 
-import Reporter from "@/components/OwnerAndReviewers/Reporter";
+import Reporter from "@/components/Reporter";
 import config from "@/config";
 import { PagesServices } from "@/services/api/services/pages";
 import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";

--- a/static/client/pages/NewWebpage/NewWebpage.tsx
+++ b/static/client/pages/NewWebpage/NewWebpage.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 
+import type { MultiSelectItem } from "@canonical/react-components";
 import { Button, Input, Spinner } from "@canonical/react-components";
 
 import NavigationItems from "@/components/Navigation/NavigationItems";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
+import Products from "@/components/OwnerAndReviewers/Products";
 import { usePages } from "@/services/api/hooks/pages";
 import { PagesServices } from "@/services/api/services/pages";
 import type { IUser } from "@/services/api/types/users";
@@ -23,6 +25,7 @@ const NewWebpage = (): JSX.Element => {
   const [copyDoc, setCopyDoc] = useState<string>();
   const [owner, setOwner] = useState<IUser | null>();
   const [reviewers, setReviewers] = useState<IUser[]>([]);
+  const [products, setProducts] = useState<number[]>([]);
   const [location, setLocation] = useState<string>();
   const [buttonDisabled, setButtonDisabled] = useState(true);
   const [reloading, setReloading] = useState<(typeof LoadingState)[keyof typeof LoadingState]>(LoadingState.INITIAL);
@@ -56,6 +59,10 @@ const NewWebpage = (): JSX.Element => {
     setLocation(path);
   }, []);
 
+  const handleSelectProducts = useCallback((products: MultiSelectItem[]) => {
+    setProducts(products.map((p) => Number(p.value)));
+  }, []);
+
   const handleSubmit = useCallback(() => {
     if (titleValue && owner && selectedProject && location) {
       setReloading(LoadingState.LOADING);
@@ -66,6 +73,7 @@ const NewWebpage = (): JSX.Element => {
         reviewers,
         project: selectedProject.name,
         parent: location,
+        product_ids: products,
       };
       PagesServices.createPage(newPage).then(() => {
         // refetch the tree from the backend after a new webpage is added to the database
@@ -75,7 +83,7 @@ const NewWebpage = (): JSX.Element => {
           });
       });
     }
-  }, [titleValue, location, copyDoc, owner, reviewers, selectedProject, refetch]);
+  }, [titleValue, owner, selectedProject, location, copyDoc, reviewers, products, refetch]);
 
   // update navigation after new page is added to the tree on the backend
   useEffect(() => {
@@ -124,6 +132,8 @@ const NewWebpage = (): JSX.Element => {
         />
       </div>
       <OwnerAndReviewers onSelectOwner={handleSelectOwner} onSelectReviewers={handleSelectReviewers} />
+      <div className="u-sv3" />
+      <Products onSelectProducts={handleSelectProducts} />
       <Button appearance="positive" className="l-new-webpage--submit" disabled={buttonDisabled} onClick={handleSubmit}>
         {reloading === LoadingState.LOADING ? <Spinner /> : `Save${copyDoc ? "" : " and generate copy doc"}`}
       </Button>

--- a/static/client/pages/NewWebpage/NewWebpage.tsx
+++ b/static/client/pages/NewWebpage/NewWebpage.tsx
@@ -5,7 +5,7 @@ import { Button, Input, Spinner } from "@canonical/react-components";
 
 import NavigationItems from "@/components/Navigation/NavigationItems";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
-import Products from "@/components/OwnerAndReviewers/Products";
+import Products from "@/components/Products";
 import { usePages } from "@/services/api/hooks/pages";
 import { PagesServices } from "@/services/api/services/pages";
 import type { IUser } from "@/services/api/types/users";

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -6,6 +6,7 @@ import { type IWebpageProps } from "./Webpage.types";
 
 import JiraTasks from "@/components/JiraTasks";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
+import Products from "@/components/OwnerAndReviewers/Products";
 import RequestTaskModal from "@/components/RequestTaskModal";
 import config from "@/config";
 import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";
@@ -115,6 +116,8 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
         )}
         <div className={isNew ? "col-12" : "col-5"}>
           <OwnerAndReviewers page={page} />
+          <div className="u-sv3" />
+          <Products page={page} />
         </div>
       </div>
       {page.jira_tasks?.length ? (

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -6,7 +6,7 @@ import { type IWebpageProps } from "./Webpage.types";
 
 import JiraTasks from "@/components/JiraTasks";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
-import Products from "@/components/OwnerAndReviewers/Products";
+import Products from "@/components/Products";
 import RequestTaskModal from "@/components/RequestTaskModal";
 import config from "@/config";
 import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -8,6 +8,8 @@ export const ENDPOINTS = {
   requestChanges: "/api/request-changes",
   requestRemoval: "/api/request-removal",
   currentUser: "/api/current-user",
+  getProducts: "/api/get-products",
+  setProducts: "/api/set-product",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/hooks/products.ts
+++ b/static/client/services/api/hooks/products.ts
@@ -10,10 +10,8 @@ export function useProducts(): IUseQueryHookRest<IProductsResponse> {
     queryFn: ProductsServices.getProducts,
   });
 
-  const isLoading = result.isLoading;
-  const isFetching = result.isFetching;
   const error = result.error;
   const data = result.data;
 
-  return { isLoading, data, error, isFetching };
+  return { data, error };
 }

--- a/static/client/services/api/hooks/products.ts
+++ b/static/client/services/api/hooks/products.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "react-query";
+
+import { ProductsServices } from "@/services/api/services/products";
+import type { IProductsResponse } from "@/services/api/types/products";
+import type { IApiBasicError, IUseQueryHookRest } from "@/services/api/types/query";
+
+export function useProducts(): IUseQueryHookRest<IProductsResponse> {
+  const result = useQuery<IProductsResponse, IApiBasicError>({
+    queryKey: "products",
+    queryFn: ProductsServices.getProducts,
+  });
+
+  const isLoading = result.isLoading;
+  const isFetching = result.isFetching;
+  const error = result.error;
+  const data = result.data;
+
+  return { isLoading, data, error, isFetching };
+}

--- a/static/client/services/api/index.ts
+++ b/static/client/services/api/index.ts
@@ -1,13 +1,16 @@
 import { PagesApiClass } from "./partials/PagesApiClass";
+import { ProductsApiClass } from "./partials/ProductsApiClass";
 import { UsersApiClass } from "./partials/UsersApiClass";
 
 class ApiClass {
   public pages: PagesApiClass;
   public users: UsersApiClass;
+  public products: ProductsApiClass;
 
   constructor() {
     this.pages = new PagesApiClass();
     this.users = new UsersApiClass();
+    this.products = new ProductsApiClass();
   }
 }
 

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -7,6 +7,7 @@ import type {
   IPagesResponse,
   IRequestChanges,
   IRequestRemoval,
+  ISetProducts,
 } from "@/services/api/types/pages";
 import { type IUser } from "@/services/api/types/users";
 
@@ -39,5 +40,9 @@ export class PagesApiClass extends BasicApiClass {
 
   public requestRemoval(body: IRequestRemoval): Promise<void> {
     return this.callApi(ENDPOINTS.requestRemoval, REST_TYPES.POST, body);
+  }
+
+  public setProducts(body: ISetProducts) {
+    return this.callApi(ENDPOINTS.setProducts, REST_TYPES.POST, body);
   }
 }

--- a/static/client/services/api/partials/ProductsApiClass.ts
+++ b/static/client/services/api/partials/ProductsApiClass.ts
@@ -1,0 +1,10 @@
+import { BasicApiClass } from "./BasicApiClass";
+
+import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
+import type { IProductsResponse } from "@/services/api/types/products";
+
+export class ProductsApiClass extends BasicApiClass {
+  public getProducts(): Promise<IProductsResponse> {
+    return this.callApi<IProductsResponse>(ENDPOINTS.getProducts, REST_TYPES.GET);
+  }
+}

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -5,6 +5,7 @@ import type {
   IPagesResponse,
   IRequestChanges,
   IRequestRemoval,
+  ISetProducts,
 } from "@/services/api/types/pages";
 import type { IUser } from "@/services/api/types/users";
 
@@ -30,6 +31,10 @@ export const requestChanges = async (body: IRequestChanges): Promise<void> => {
 
 export const requestRemoval = async (body: IRequestRemoval): Promise<void> => {
   return api.pages.requestRemoval(body);
+};
+
+export const setProducts = async (body: ISetProducts) => {
+  return api.pages.setProducts(body);
 };
 
 export * as PagesServices from "./pages";

--- a/static/client/services/api/services/products.ts
+++ b/static/client/services/api/services/products.ts
@@ -1,0 +1,8 @@
+import { api } from "@/services/api";
+import type { IProductsResponse } from "@/services/api/types/products";
+
+export const getProducts = async (): Promise<IProductsResponse> => {
+  return api.products.getProducts();
+};
+
+export * as ProductsServices from "./products";

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -1,3 +1,4 @@
+import type { IProduct } from "./products";
 import type { IUser } from "./users";
 
 export const PageStatus = {
@@ -26,6 +27,7 @@ export interface IPage {
   status: (typeof PageStatus)[keyof typeof PageStatus];
   jira_tasks: IJiraTask[];
   children: IPage[];
+  products: IProduct[];
 }
 
 export interface IPagesResponse {
@@ -69,4 +71,9 @@ export interface IRequestRemoval {
   reporter_struct: IUser;
   webpage_id: number;
   description: string;
+}
+
+export interface ISetProducts {
+  webpage_id: number;
+  product_ids: number[];
 }

--- a/static/client/services/api/types/products.ts
+++ b/static/client/services/api/types/products.ts
@@ -1,0 +1,8 @@
+export interface IProduct {
+  id: number;
+  name: string;
+}
+
+export interface IProductsResponse {
+  data: IProduct[];
+}

--- a/static/client/services/api/types/query.ts
+++ b/static/client/services/api/types/query.ts
@@ -10,7 +10,7 @@ export interface IApiBasicError {
 }
 
 interface IUseQueryHookBase<T extends unknown> {
-  isLoading: boolean;
+  isLoading?: boolean;
   data: T | undefined;
   refetch?: () => Promise<QueryObserverResult<IPagesResponse, IApiBasicError>[]>;
   isFetching?: boolean;

--- a/webapp/routes/jira.py
+++ b/webapp/routes/jira.py
@@ -18,6 +18,7 @@ from webapp.models import (
     Reviewer,
     User,
     Webpage,
+    WebpageProduct,
     WebpageStatus,
     db,
     get_or_create,
@@ -196,6 +197,7 @@ def create_page(body: CreatePageModel):
     data = body.model_dump()
 
     owner_id = get_or_create_user_id(data["owner"])
+    product_ids = data["product_ids"]
 
     # Create new webpage
     project_id = get_project_id(data["project"])
@@ -226,5 +228,14 @@ def create_page(body: CreatePageModel):
         copy_doc = create_copy_doc(current_app, new_webpage[0])
         new_webpage[0].copy_doc_link = copy_doc
         db.session.commit()
+
+    # Set products for the webpage
+    for product_id in product_ids:
+        get_or_create(
+            db.session,
+            WebpageProduct,
+            webpage_id=new_webpage[0].id,
+            product_id=product_id
+        )
 
     return jsonify({"copy_doc": copy_doc}), 201

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -57,6 +57,7 @@ class CreatePageModel(BaseModel):
     owner: UserModel
     reviewers: Optional[List[UserModel]]
     parent: str
+    product_ids: List[int]
 
 
 class SetProductsModel(BaseModel):


### PR DESCRIPTION
## Done

 - Added a hook for fetching products from API.
 - Render products drop down on update/create webpages.
 - Pre-filled selected products for on an existing webpage.
 - Save products when creating a new web page, using `create-page` POST request.

## QA

### QA steps

 - Check out this PR
 - Make sure you have a valid `JIRA_COPY_UPDATES_EPIC` and `JIRA_TOKEN`
 - Run the application using `dotrun` command locally.
 - Open localhost:8104 in your browser.
 - Log in using Ubuntu SSO if not already.
 - Select any project and page from the left sidebar.
 - Verify the products are available in the products dropdown.
 - Assign single/multiple products from the products dropdown to the webpage.
 - Refresh the browser to verify if the products were saved successfully.
 - Now, click on the `Request new page` button in the left side.
 - Fill in the new webpage form, and assign a few products.
 - After hitting submit, you should be redirected to the newly created page's details page and the products should be pre-filled.


## Fixes

 - Fixes [WD-16243](https://warthogs.atlassian.net/browse/WD-16243)


[WD-16243]: https://warthogs.atlassian.net/browse/WD-16243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ