### PR TITLE
extend SSO access to all Canonical employees

### DIFF
--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -7,7 +7,7 @@ from webapp.helper import get_or_create_user_id, get_user_from_directory_by_key
 from webapp.models import User
 
 SSO_LOGIN_URL = "https://login.ubuntu.com"
-SSO_TEAM = "canonical-webmonkeys"
+SSO_TEAM = "canonical"
 DISABLE_SSO = os.environ.get("DISABLE_SSO")
 
 


### PR DESCRIPTION
## Done

 - Extending access to everyone at Canonical instead of only those in Webmonkeys group.

## QA

### QA steps

 - Open the demo and check that you can successfully login to the app.
