### PR TITLE
feat: Use canonical launchpad group on prod

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -149,3 +149,6 @@ demo:
       secretKeyRef:
         key: google-private-key-id
         name: cs-canonical-com
+
+    - name: FLASK_DEBUG
+      value: "1"

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -7,7 +7,9 @@ from webapp.helper import get_or_create_user_id, get_user_from_directory_by_key
 from webapp.models import User
 
 SSO_LOGIN_URL = "https://login.ubuntu.com"
-SSO_TEAM = "canonical-webmonkeys"
+SSO_TEAM = (
+    "canonical-webmonkeys" if os.environ.get("FLASK_DEBUG") else "canonical"
+)
 DISABLE_SSO = os.environ.get("DISABLE_SSO")
 
 


### PR DESCRIPTION
## Done

 - Use the `canonical-webmonkeys` launchpad team if the `flask-debug` env variable is set, otherwise use the `canonical` group.

## QA 

 - Open the demo and confirm that it allows logging in. 
 - Staging has been updated with this PR. Open https://cs.staging.canonical.com in incognito, to confirm that both teams allow access after logging in.
