### PR TITLE
[WD-19796] Persist postgres data across container restarts on local dev environemnt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       timeout: 3s
       retries: 10
       start_period: 80s
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
 volumes:
   cache:
+    driver: local
+  postgres_data:
     driver: local


### PR DESCRIPTION
## Done

 - Persist data across container restarts on dev enviroment.

## Fixes

 - Fixes [WD-19796](https://warthogs.atlassian.net/browse/WD-19796)


[WD-19796]: https://warthogs.atlassian.net/browse/WD-19796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ