### PR TITLE
[WD-19801] feat: find webpage by copydoc and open wepage overview

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,9 @@
 from os import environ
-from flask import render_template
+from flask import redirect, render_template, request
+import urllib
 
 from webapp import create_app
+from webapp.models import Webpage
 from webapp.sso import login_required
 from webapp.routes.tree import tree_blueprint
 from webapp.routes.user import user_blueprint
@@ -22,6 +24,16 @@ app.register_blueprint(product_blueprint)
 @app.route("/app/new-webpage")
 @login_required
 def index():
+    copydoc = request.args.get("copydoc")
+    if copydoc:
+        copydoc = urllib.parse.unquote(copydoc)
+        webpage = Webpage.query.filter(
+            Webpage.copy_doc_link.ilike(f"%{copydoc}%")
+        ).first()
+        if webpage:
+            return redirect(
+                f"/app/webpage/{webpage.project.name}{webpage.url}"
+            )
     return render_template(
         "index.html", is_dev=environ.get("FLASK_ENV") == "development"
     )


### PR DESCRIPTION
## Done

 - Modified the root endpoint so it accepts a query param for copydoc, and if valid, will find the webpage for the given copydoc and open details page

## QA

### QA steps

 - Open this [demo](https://cs-canonical-com-164.demos.haus/app) in your web browser
 - Select any project and page from the left sidebar
 - Copy the copydoc link for the page
 - Open another tab, and paste the following link in the address bar:
 `https://cs-canonical-com-164.demos.haus/app?copydoc=<copydoc_link>`
Replace the `copydoc_link` with the copydoc link of the webpage you copied earlier.
- This should open up the exact same webpage.

## Fixes

 - Fixes [WD-19801](https://warthogs.atlassian.net/browse/WD-19801)


[WD-19801]: https://warthogs.atlassian.net/browse/WD-19801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ