### PR TITLE
[WD-19885] Add more projects to content system + fix issue of missing children for jp.ubuntu.com

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -1,3 +1,5 @@
 sites:
  - ubuntu.com
  - canonical.com
+ - cn.ubuntu.com
+ - jp.ubuntu.com

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -1,7 +1,7 @@
 let staleTime = process.env.NODE_ENV === "production" ? 300000 : 30000;
 
 const config = {
-  projects: ["canonical.com", "ubuntu.com"],
+  projects: ["canonical.com", "ubuntu.com", "cn.ubuntu.com", "jp.ubuntu.com"],
   api: {
     path: "/",
     FETCH_OPTIONS: {

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -7,6 +7,7 @@ BASE_TEMPLATES = [
     "templates/base.html",
     "templates/base_no_nav.html",
     "templates/one-column.html",
+    "_base/base.html",
 ]
 TEMPLATE_PREFIXES = ["base", "_base"]
 TAG_MAPPING = {


### PR DESCRIPTION
## Done

 - Added `cn.ubuntu.com` and `jp.ubuntu.com`
 - Added base template for jp.ubuntu.com

## QA

### QA steps

 - Check out this [demo](https://cs-canonical-com-165.demos.haus/)
 - Verify that the jp.ubuntu.com and cn.ubuntu.com projects are visible in the project dropdown in left sidebar
 - Select both of these projects one by one and verify their children show up.

## Fixes

 - Fixes [WD-19885](https://warthogs.atlassian.net/browse/WD-19885)


[WD-19885]: https://warthogs.atlassian.net/browse/WD-19885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ