### PR TITLE
WD-16247 Dev highlight webpages that are new or to be deleted

### DIFF
--- a/.env
+++ b/.env
@@ -18,3 +18,4 @@ GOOGLE_DRIVE_FOLDER_ID=googlecreds
 COPYDOC_TEMPLATE_ID=googlecreds
 GOOGLE_PRIVATE_KEY=base64encodedprivatekey
 GOOGLE_PRIVATE_KEY_ID=privatekeyid
+FLASK_DEBUG=1

--- a/.env
+++ b/.env
@@ -18,4 +18,3 @@ GOOGLE_DRIVE_FOLDER_ID=googlecreds
 COPYDOC_TEMPLATE_ID=googlecreds
 GOOGLE_PRIVATE_KEY=base64encodedprivatekey
 GOOGLE_PRIVATE_KEY_ID=privatekeyid
-FLASK_DEBUG=1

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-dom": "18.3.1",
     "react-query": "3.39.3",
     "react-router-dom": "6.29.0",
-    "vanilla-framework": "4.16.0",
+    "vanilla-framework": "4.21.0",
     "zustand": "4.5.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "formik": "2.4.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-icons": "^5.5.0",
     "react-query": "3.39.3",
     "react-router-dom": "6.29.0",
     "vanilla-framework": "4.16.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "formik": "2.4.6",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-icons": "^5.5.0",
     "react-query": "3.39.3",
     "react-router-dom": "6.29.0",
     "vanilla-framework": "4.16.0",

--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -20,6 +20,7 @@
 @include vf-p-icons;
 @include vf-p-icons-common;
 @include vf-p-icon-edit;
+@include vf-p-icon-archive;
 
 // Utilities
 @include vf-u-align;

--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -19,6 +19,7 @@
 // Icons
 @include vf-p-icons;
 @include vf-p-icons-common;
+@include vf-p-icon-edit;
 
 // Utilities
 @include vf-u-align;

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -58,42 +58,44 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
     }
   }, [activePageName, page.name]);
 
-  let statusIcon;
-  if (page.status === PageStatus.NEW) {
-    statusIcon = (
-      <Tooltip
-        autoAdjust
-        message={
-          <>
-            <b>In drafts</b>
-            <br />
-            This page isn't live yet.
-          </>
-        }
-        position="right"
-        zIndex={1000}
-      >
-        <i className="p-icon--edit is-dark" />
-      </Tooltip>
-    );
-  } else if (page.status === PageStatus.TO_DELETE) {
-    statusIcon = (
-      <Tooltip
-        autoAdjust
-        message={
-          <>
-            <b>To be deleted</b>
-            <br />
-            This page is being deleted.
-          </>
-        }
-        position="right"
-        zIndex={1000}
-      >
-        <i className="p-icon--delete is-dark" />
-      </Tooltip>
-    );
-  }
+  const statusIcon = useCallback(() => {
+    if (page.status === PageStatus.NEW)
+      return (
+        <Tooltip
+          autoAdjust
+          message={
+            <>
+              <b>In drafts</b>
+              <br />
+              This page isn't live yet.
+            </>
+          }
+          position="right"
+          zIndex={1000}
+        >
+          <i className="p-icon--edit is-dark" />
+        </Tooltip>
+      );
+    if (page.status === PageStatus.TO_DELETE)
+      return (
+        <Tooltip
+          autoAdjust
+          message={
+            <>
+              <b>To be deleted</b>
+              <br />
+              This page is being deleted.
+            </>
+          }
+          position="right"
+          zIndex={1000}
+        >
+          <i className="p-icon--archive is-dark" />
+        </Tooltip>
+      );
+
+    return <></>;
+  }, [page.status]);
 
   return (
     <li
@@ -112,7 +114,8 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
               onClick={toggleElement}
               ref={expandButtonRef}
             >
-              {NavigationServices.formatPageName(page.name)} {statusIcon}
+              {NavigationServices.formatPageName(page.name)}
+              {statusIcon()}
             </button>
           </>
           <ul
@@ -131,7 +134,7 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         </>
       ) : (
         <div className={`p-list-tree__link ${page.name === activePageName ? "is-active" : ""}`} onClick={handleSelect}>
-          {NavigationServices.formatPageName(page.name)} {statusIcon}
+          {NavigationServices.formatPageName(page.name)} {statusIcon()}
         </div>
       )}
     </li>

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -1,10 +1,13 @@
 import React, { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 
+import { Tooltip } from "@canonical/react-components";
+import { LuPencilLine } from "react-icons/lu";
+import { MdAutoDelete } from "react-icons/md";
 import { useLocation } from "react-router-dom";
 
 import { type INavigationElementProps } from "./NavigationElement.types";
 
-import type { IPage } from "@/services/api/types/pages";
+import { IPage, PageStatus } from "@/services/api/types/pages";
 import { NavigationServices } from "@/services/navigation";
 
 const NavigationElement = ({ activePageName, page, project, onSelect }: INavigationElementProps): JSX.Element => {
@@ -56,6 +59,45 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
     }
   }, [activePageName, page.name]);
 
+  let statusIcon;
+  if (page.status === PageStatus.NEW) {
+    statusIcon = (
+      <Tooltip
+        autoAdjust
+        message={
+          <>
+            <b>In drafts</b>
+            <br />
+            This page isn't live yet.
+          </>
+        }
+        position="right"
+        zIndex={1000}
+        className={"is-light"}
+      >
+        <LuPencilLine />
+      </Tooltip>
+    );
+  } else if (page.status === PageStatus.TO_DELETE) {
+    statusIcon = (
+      <Tooltip
+        autoAdjust
+        message={
+          <>
+            <b>To be deleted</b>
+            <br />
+            This page is being deleted.
+          </>
+        }
+        position="right"
+        zIndex={1000}
+        className={"is-light"}
+      >
+        <MdAutoDelete />
+      </Tooltip>
+    );
+  }
+
   return (
     <li
       aria-selected={page.name === activePageName}
@@ -73,7 +115,7 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
               onClick={toggleElement}
               ref={expandButtonRef}
             >
-              {NavigationServices.formatPageName(page.name)}
+              {NavigationServices.formatPageName(page.name)} {statusIcon}
             </button>
           </>
           <ul
@@ -92,7 +134,7 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         </>
       ) : (
         <div className={`p-list-tree__link ${page.name === activePageName ? "is-active" : ""}`} onClick={handleSelect}>
-          {NavigationServices.formatPageName(page.name)}
+          {NavigationServices.formatPageName(page.name)} {statusIcon}
         </div>
       )}
     </li>

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -1,13 +1,12 @@
 import React, { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 
 import { Tooltip } from "@canonical/react-components";
-import { LuPencilLine } from "react-icons/lu";
-import { MdAutoDelete } from "react-icons/md";
 import { useLocation } from "react-router-dom";
 
 import { type INavigationElementProps } from "./NavigationElement.types";
 
-import { IPage, PageStatus } from "@/services/api/types/pages";
+import type { IPage } from "@/services/api/types/pages";
+import { PageStatus } from "@/services/api/types/pages";
 import { NavigationServices } from "@/services/navigation";
 
 const NavigationElement = ({ activePageName, page, project, onSelect }: INavigationElementProps): JSX.Element => {
@@ -73,9 +72,8 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         }
         position="right"
         zIndex={1000}
-        className={"is-light"}
       >
-        <LuPencilLine />
+        <i className="p-icon--edit is-dark" />
       </Tooltip>
     );
   } else if (page.status === PageStatus.TO_DELETE) {
@@ -91,9 +89,8 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         }
         position="right"
         zIndex={1000}
-        className={"is-light"}
       >
-        <MdAutoDelete />
+        <i className="p-icon--delete is-dark" />
       </Tooltip>
     );
   }

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -1,12 +1,11 @@
 import React, { type MouseEvent, useCallback, useEffect, useRef, useState } from "react";
 
-import { Tooltip } from "@canonical/react-components";
 import { useLocation } from "react-router-dom";
 
 import { type INavigationElementProps } from "./NavigationElement.types";
+import NavigationElementBadge from "./NavigationElementBadge";
 
 import type { IPage } from "@/services/api/types/pages";
-import { PageStatus } from "@/services/api/types/pages";
 import { NavigationServices } from "@/services/navigation";
 
 const NavigationElement = ({ activePageName, page, project, onSelect }: INavigationElementProps): JSX.Element => {
@@ -58,45 +57,6 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
     }
   }, [activePageName, page.name]);
 
-  const statusIcon = useCallback(() => {
-    if (page.status === PageStatus.NEW)
-      return (
-        <Tooltip
-          autoAdjust
-          message={
-            <>
-              <b>In drafts</b>
-              <br />
-              This page isn't live yet.
-            </>
-          }
-          position="right"
-          zIndex={1000}
-        >
-          <i className="p-icon--edit is-dark" />
-        </Tooltip>
-      );
-    if (page.status === PageStatus.TO_DELETE)
-      return (
-        <Tooltip
-          autoAdjust
-          message={
-            <>
-              <b>To be deleted</b>
-              <br />
-              This page is being deleted.
-            </>
-          }
-          position="right"
-          zIndex={1000}
-        >
-          <i className="p-icon--archive is-dark" />
-        </Tooltip>
-      );
-
-    return <></>;
-  }, [page.status]);
-
   return (
     <li
       aria-selected={page.name === activePageName}
@@ -115,7 +75,7 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
               ref={expandButtonRef}
             >
               {NavigationServices.formatPageName(page.name)}
-              {statusIcon()}
+              <NavigationElementBadge page={page} />
             </button>
           </>
           <ul
@@ -134,7 +94,8 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         </>
       ) : (
         <div className={`p-list-tree__link ${page.name === activePageName ? "is-active" : ""}`} onClick={handleSelect}>
-          {NavigationServices.formatPageName(page.name)} {statusIcon()}
+          {NavigationServices.formatPageName(page.name)}
+          <NavigationElementBadge page={page} />
         </div>
       )}
     </li>

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
@@ -6,3 +6,7 @@ export interface INavigationElementProps {
   project: string;
   onSelect: (path: string) => void;
 }
+
+export interface INavigationElementBadgeProps {
+  page: IPage;
+}

--- a/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from "react";
+
+import { Tooltip } from "@canonical/react-components";
+
+import type { IPage } from "@/services/api/types/pages";
+import { PageStatus } from "@/services/api/types/pages";
+
+const NavigationElementBadge = ({ page }: { page: IPage }): JSX.Element => {
+  const getIcon = useMemo(() => {
+    switch (page.status) {
+      case PageStatus.NEW:
+        return <i className="p-icon--edit is-dark" />;
+      case PageStatus.TO_DELETE:
+        return <i className="p-icon--archive is-dark" />;
+      default:
+        return <></>;
+    }
+  }, [page.status]);
+
+  const getTitle = useMemo(() => {
+    switch (page.status) {
+      case PageStatus.NEW:
+        return "In drafts";
+      case PageStatus.TO_DELETE:
+        return "To be deleted";
+      default:
+        return null;
+    }
+  }, [page.status]);
+
+  const getText = useMemo(() => {
+    switch (page.status) {
+      case PageStatus.NEW:
+        return "This page isn't live yet.";
+      case PageStatus.TO_DELETE:
+        return "This page is being deleted.";
+      default:
+        return null;
+    }
+  }, [page.status]);
+
+  return (
+    <Tooltip
+      autoAdjust
+      message={
+        <>
+          <b>{getTitle}</b>
+          <br />
+          {getText}
+        </>
+      }
+      position="right"
+      zIndex={1000}
+    >
+      <div>{getIcon}</div>
+    </Tooltip>
+  );
+};
+
+export default NavigationElementBadge;

--- a/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
@@ -2,10 +2,11 @@ import React, { useMemo } from "react";
 
 import { Tooltip } from "@canonical/react-components";
 
-import type { IPage } from "@/services/api/types/pages";
+import type { INavigationElementBadgeProps } from "./NavigationElement.types";
+
 import { PageStatus } from "@/services/api/types/pages";
 
-const NavigationElementBadge = ({ page }: { page: IPage }): JSX.Element => {
+const NavigationElementBadge = ({ page }: INavigationElementBadgeProps): JSX.Element => {
   const getIcon = useMemo(() => {
     switch (page.status) {
       case PageStatus.NEW:

--- a/static/client/components/Navigation/NavigationElement/_NavigationElement.scss
+++ b/static/client/components/Navigation/NavigationElement/_NavigationElement.scss
@@ -13,3 +13,8 @@
   margin-right: 0;
   padding-right: 0;
 }
+
+.p-list-tree__link {
+  display: flex;
+  gap: 0.3rem;
+}

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -77,40 +77,26 @@ const RequestTaskModal = ({
       })
         .then(() => {
           onClose();
-          if (webpage.status === PageStatus.NEW) {
-            if (refetch) {
-              refetch()
-                .then((data) => {
-                  if (data?.length) {
-                    const project = data.find((p) => p.data?.data?.name === selectedProject?.name);
-                    if (project && project.data?.data) {
-                      setSelectedProject(project.data.data);
-                    }
-                  }
-                })
-                .finally(() => {
-                  navigate("/app", { replace: true });
-                });
-            } else {
+          const afterRefetch = () => {
+            if (webpage.status === PageStatus.NEW) {
               navigate("/app", { replace: true });
-            }
-          } else {
-            if (refetch) {
-              refetch()
-                .then((data) => {
-                  if (data?.length) {
-                    const project = data.find((p) => p.data?.data?.name === selectedProject?.name);
-                    if (project && project.data?.data) {
-                      setSelectedProject(project.data.data);
-                    }
-                  }
-                })
-                .finally(() => {
-                  window.location.reload();
-                });
             } else {
               window.location.reload();
             }
+          };
+          if (refetch) {
+            refetch()
+              .then((data) => {
+                if (data?.length) {
+                  const project = data.find((p) => p.data?.data?.name === selectedProject?.name);
+                  if (project && project.data?.data) {
+                    setSelectedProject(project.data.data);
+                  }
+                }
+              })
+              .finally(afterRefetch);
+          } else {
+            afterRefetch();
           }
         })
         .catch((error) => {

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -95,7 +95,22 @@ const RequestTaskModal = ({
               navigate("/app", { replace: true });
             }
           } else {
-            window.location.reload();
+            if (refetch) {
+              refetch()
+                .then((data) => {
+                  if (data?.length) {
+                    const project = data.find((p) => p.data?.data?.name === selectedProject?.name);
+                    if (project && project.data?.data) {
+                      setSelectedProject(project.data.data);
+                    }
+                  }
+                })
+                .finally(() => {
+                  window.location.reload();
+                });
+            } else {
+              window.location.reload();
+            }
           }
         })
         .catch((error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,6 +5611,11 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-icons@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
+  integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6941,10 +6941,10 @@ validate-npm-package-name@^5.0.1:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
-vanilla-framework@4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
-  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
+vanilla-framework@4.21.0:
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.21.0.tgz#745e6d4cff71b9d2a976540fc8041478d43127ae"
+  integrity sha512-/qQu0J5L17Oumpd9AD+kqEYgkBm/JjOJNO3ArObnw9Hx9Dk1Vt3dIasYEo9IR6QFAMU64daOXqbFB+Dz8fZmxw==
 
 verbalize@^0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,11 +5611,6 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-icons@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.5.0.tgz#8aa25d3543ff84231685d3331164c00299cdfaf2"
-  integrity sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## Done

 - Added tooltip icons for pages that are NEW or TO_DELETE.
 - Added react-icons package that works well with dark/light theme backgrounds.
 - Fixed bug: stale data after page removal.

## QA

### QA steps

 - Run project locally.
 - See if you could get the team-membership on sso page.
 - Try removing existing pages and asking for new pages and see if the icon appears according to the [figma design](https://www.figma.com/design/uVXFi46C7ZgriDoWEnsv1U/24.10-Content-system-(CMS)?node-id=307-7371)
 - After remove-request, navigation is refreshed to show the latest changes.

## Fixes

 - Fixes [WD-16247](https://warthogs.atlassian.net/browse/WD-16247)

## Screenshots

![image](https://github.com/user-attachments/assets/fbd34036-2c31-47e1-bf2f-876fadcc86cc)
![image](https://github.com/user-attachments/assets/028776b0-b6d7-40cf-ab64-5af865574e1b)


[WD-16247]: https://warthogs.atlassian.net/browse/WD-16247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ