### PR TITLE
feat: project views, filters and more

### DIFF
--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -74,3 +74,7 @@
     padding-left: 0 !important;
   }
 }
+
+.p-table__row--highlight{
+  background: var(--vf-color-background-neutral-hover) !important;
+}

--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -60,12 +60,17 @@
   height: auto !important;
 }
 
-.p-accordion__heading {
-  position: sticky !important;
-  top: -1.5rem;
-  z-index: 9;
-
-  & button[aria-expanded="true"]{
-    background: var(--vf-color-background-neutral-hover) !important;
+.p-accordion {
+  .p-accordion__heading {
+    position: sticky !important;
+    top: -1.5rem;
+    z-index: 9;
+  
+    & button[aria-expanded="true"]{
+      background: var(--vf-color-background-neutral-hover) !important;
+    }
+  }
+  .p-accordion__panel {
+    padding-left: 0 !important;
   }
 }

--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -21,6 +21,8 @@
 @include vf-p-icons-common;
 @include vf-p-icon-edit;
 @include vf-p-icon-archive;
+@include vf-p-icon-switcher-dashboard;
+@include vf-p-icon-switcher-environments;
 
 // Utilities
 @include vf-u-align;
@@ -56,4 +58,14 @@
 // allow SearchAndFilter component increase height when there are several options selected (in Reviewers)
 .p-search-and-filter__search-container {
   height: auto !important;
+}
+
+.p-accordion__heading {
+  position: sticky !important;
+  top: -1.5rem;
+  z-index: 9;
+
+  & button[aria-expanded="true"]{
+    background: var(--vf-color-background-neutral-hover) !important;
+  }
 }

--- a/static/client/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/static/client/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from "react";
 
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { type IBreadcrumb } from "./Breadcrumbs.types";
 
 const Breadcrumbs = () => {
   const location = useLocation();
   const [breadcrumbs, setBreadcrumbs] = useState<IBreadcrumb[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const pageIndex = location.pathname.indexOf("app/webpage/");
@@ -28,12 +29,20 @@ const Breadcrumbs = () => {
     }
   }, [location]);
 
+  const goToPage = React.useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>, path: string) => {
+      e.preventDefault();
+      navigate(path);
+    },
+    [navigate],
+  );
+
   return (
     <div className="l-breadcrumbs">
       {breadcrumbs.map((bc, index) => (
         <React.Fragment key={`bc-${index}`}>
           {index < breadcrumbs.length - 1 ? (
-            <a className="p-text--small-caps" href={bc.link}>
+            <a className="p-text--small-caps" href={bc.link} onClick={(e) => goToPage(e, bc.link)}>
               {bc.name}
             </a>
           ) : (

--- a/static/client/components/Common/IconTextWithTooltip.tsx
+++ b/static/client/components/Common/IconTextWithTooltip.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { Tooltip } from "@canonical/react-components";
+
+interface IIconTextWithTooltipProps {
+  text?: string;
+  icon?: string;
+  message?: string;
+}
+
+const IconTextWithTooltip: React.FC<IIconTextWithTooltipProps> = ({ text, icon, message }) => {
+  return (
+    <Tooltip message={message} zIndex={999}>
+      <span className="u-has-icon">
+        {text}&nbsp;
+        {icon && <i className={`p-icon--${icon}`} />}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default IconTextWithTooltip;

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -1,9 +1,10 @@
 import { NotificationConsumer } from "@canonical/react-components";
-import { useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import Breadcrumbs from "@/components/Breadcrumbs";
 import Navigation from "@/components/Navigation";
 import Search from "@/components/Search";
+import TableView from "@/components/Views/TableView";
 
 interface IMainLayoutProps {
   children?: JSX.Element;
@@ -29,11 +30,12 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
           <div className="row">
             {location.pathname === "/app" && (
               <>
-                <h2>Welcome to the Content System</h2>
-                <h3 className="p-heading--4">Please select a page that you are looking for from the left sidebar</h3>
+                <h2>All pages</h2>
+                <TableView />
               </>
             )}
             {children}
+            <Outlet />
           </div>
         </main>
         <div className="l-notification__container">

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -1,10 +1,13 @@
-import { NotificationConsumer } from "@canonical/react-components";
-import { Outlet, useLocation } from "react-router-dom";
+import React from "react";
 
-import Breadcrumbs from "@/components/Breadcrumbs";
+import { Button, NotificationConsumer } from "@canonical/react-components";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+
 import Navigation from "@/components/Navigation";
 import Search from "@/components/Search";
 import TableView from "@/components/Views/TableView";
+import { VIEW_TREE } from "@/config";
+import { useViewsStore } from "@/store/views";
 
 interface IMainLayoutProps {
   children?: JSX.Element;
@@ -12,6 +15,8 @@ interface IMainLayoutProps {
 
 const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const view = useViewsStore((state) => state.view);
 
   return (
     <>
@@ -20,7 +25,13 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
         <main className="l-main">
           <div className="row">
             <div className="col-7">
-              <Breadcrumbs />
+              {location.pathname.includes("/webpage") && view !== VIEW_TREE && true && (
+                <Button hasIcon onClick={() => navigate(-1)}>
+                  <React.Fragment key=".0">
+                    <i className="p-icon--chevron-left" /> <span>Back</span>
+                  </React.Fragment>
+                </Button>
+              )}
             </div>
             <div className="col-5">
               <Search />

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -30,7 +30,7 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
         <main className="l-main">
           <div className="row">
             <div className="col-7">
-              {location.pathname.includes("/webpage") && view !== VIEW_TREE && true && (
+              {location.pathname.includes("/webpage") && view !== VIEW_TREE && (
                 <Button hasIcon onClick={goPrev}>
                   <React.Fragment key=".0">
                     <i className="p-icon--chevron-left" /> <span>Back</span>

--- a/static/client/components/MainLayout/MainLayout.tsx
+++ b/static/client/components/MainLayout/MainLayout.tsx
@@ -7,6 +7,7 @@ import Navigation from "@/components/Navigation";
 import Search from "@/components/Search";
 import TableView from "@/components/Views/TableView";
 import { VIEW_TREE } from "@/config";
+import { goBack } from "@/helpers/views";
 import { useViewsStore } from "@/store/views";
 
 interface IMainLayoutProps {
@@ -18,6 +19,10 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
   const navigate = useNavigate();
   const view = useViewsStore((state) => state.view);
 
+  function goPrev() {
+    return goBack(location, navigate);
+  }
+
   return (
     <>
       <div className="l-application">
@@ -26,7 +31,7 @@ const MainLayout = ({ children }: IMainLayoutProps): JSX.Element => {
           <div className="row">
             <div className="col-7">
               {location.pathname.includes("/webpage") && view !== VIEW_TREE && true && (
-                <Button hasIcon onClick={() => navigate(-1)}>
+                <Button hasIcon onClick={goPrev}>
                   <React.Fragment key=".0">
                     <i className="p-icon--chevron-left" /> <span>Back</span>
                   </React.Fragment>

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -109,7 +109,7 @@ const Navigation = (): JSX.Element => {
                 </>
               )}
             </div>
-            <div style={{ marginTop: "2rem" }}>
+            <div className="p-panel__views">
               <hr className="p-rule" />
               <p className="p-muted-heading u-text--muted">Quick views</p>
               <ul className="u-no-margin u-no-padding">

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -21,6 +21,7 @@ const Navigation = (): JSX.Element => {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [user, setUser] = useStore((state) => [state.user, state.setUser]);
   const [view, setView] = useViewsStore((state) => [state.view, state.setView]);
+  const setExpandedProject = useViewsStore((state) => state.setExpandedProject);
 
   const logout = useCallback(() => {
     setUser({} as IUser);
@@ -33,11 +34,12 @@ const Navigation = (): JSX.Element => {
 
   const changeView = useCallback(
     (view: TView) => {
+      setExpandedProject("");
       setView(view);
       if ([VIEW_OWNED, VIEW_REVIEWED].includes(view)) navigate(`/app/views/${view}`);
       if ([VIEW_TABLE, VIEW_TREE].includes(view)) navigate("/app");
     },
-    [navigate, setView],
+    [navigate, setExpandedProject, setView],
   );
 
   const isViewActive = useMemo(

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
@@ -42,8 +42,8 @@ const Navigation = (): JSX.Element => {
     [navigate, setExpandedProject, setView],
   );
 
-  const isViewActive = useMemo(
-    () => (linkView: TView) => {
+  const isViewActive = useCallback(
+    (linkView: TView) => {
       if (view === VIEW_TREE) return linkView === view;
       return linkView === view && location.pathname === `/app/views/${linkView}`;
     },
@@ -82,7 +82,7 @@ const Navigation = (): JSX.Element => {
             </div>
             <hr className="p-rule" />
             <div className="p-panel__content">
-              <ul className="u-no-margin u-no-padding">
+              <ul className="u-no-margin--left u-no-padding">
                 <li
                   className={`p-side-navigation__link ${location.pathname === "/app" && view !== VIEW_TREE && "is-active"}`}
                   onClick={() => changeView(VIEW_TABLE)}
@@ -95,21 +95,19 @@ const Navigation = (): JSX.Element => {
                 <li
                   className={`p-side-navigation__link ${isViewActive(VIEW_TREE) && "is-active"}`}
                   onClick={() => changeView(VIEW_TREE)}
-                  style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
                 >
                   <span className="u-has-icon">
                     <i className="p-icon--switcher-environments is-dark" />
                     Tree view
                   </span>
-
-                  {isViewActive(VIEW_TREE) && (
-                    <>
-                      <SiteSelector />
-                      <NavigationItems />
-                    </>
-                  )}
                 </li>
               </ul>
+              {isViewActive(VIEW_TREE) && (
+                <>
+                  <SiteSelector />
+                  <NavigationItems />
+                </>
+              )}
             </div>
             <div style={{ marginTop: "2rem" }}>
               <hr className="p-rule" />

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -1,21 +1,26 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import NavigationBanner from "./NavigationBanner";
 import NavigationItems from "./NavigationItems";
 
 import NavigationCollapseToggle from "@/components/Navigation/NavigationCollapseToggle";
 import SiteSelector from "@/components/SiteSelector";
+import { VIEW_OWNED, VIEW_REVIEWED, VIEW_TABLE, VIEW_TREE } from "@/config";
 import type { IUser } from "@/services/api/types/users";
+import type { TView } from "@/services/api/types/views";
 import { useStore } from "@/store";
+import { useViewsStore } from "@/store/views";
 
 const Navigation = (): JSX.Element => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [user, setUser] = useStore((state) => [state.user, state.setUser]);
+  const [view, setView] = useViewsStore((state) => [state.view, state.setView]);
 
   const logout = useCallback(() => {
     setUser({} as IUser);
@@ -25,6 +30,23 @@ const Navigation = (): JSX.Element => {
   const handleNewPageClick = useCallback(() => {
     navigate("/app/new-webpage");
   }, [navigate]);
+
+  const changeView = useCallback(
+    (view: TView) => {
+      setView(view);
+      if ([VIEW_OWNED, VIEW_REVIEWED].includes(view)) navigate(`/app/views/${view}`);
+      if ([VIEW_TABLE, VIEW_TREE].includes(view)) navigate("/app");
+    },
+    [navigate, setView],
+  );
+
+  const isViewActive = useMemo(
+    () => (linkView: TView) => {
+      if (view === VIEW_TREE) return linkView === view;
+      return linkView === view && location.pathname === `/app/views/${linkView}`;
+    },
+    [location.pathname, view],
+  );
 
   return (
     <>
@@ -48,15 +70,68 @@ const Navigation = (): JSX.Element => {
               <div className="l-navigation__controls">
                 <NavigationCollapseToggle isCollapsed={isCollapsed} setIsCollapsed={setIsCollapsed} />
               </div>
-              <SiteSelector />
-              <Button appearance="" className="l-new-webpage-button" hasIcon onClick={handleNewPageClick}>
-                <React.Fragment key=".0">
-                  <i className="p-icon--plus" /> <span>Request new page</span>
-                </React.Fragment>
-              </Button>
+              <div>
+                <Button appearance="" className="l-new-webpage-button" hasIcon onClick={handleNewPageClick}>
+                  <React.Fragment key=".0">
+                    <i className="p-icon--plus" /> <span>Request new page</span>
+                  </React.Fragment>
+                </Button>
+              </div>
             </div>
+            <hr className="p-rule" />
             <div className="p-panel__content">
-              <NavigationItems />
+              <ul className="u-no-margin u-no-padding">
+                <li
+                  className={`p-side-navigation__link ${location.pathname === "/app" && view !== VIEW_TREE && "is-active"}`}
+                  onClick={() => changeView(VIEW_TABLE)}
+                >
+                  <span className="u-has-icon">
+                    <i className="p-icon--switcher-dashboard is-dark" />
+                    Table view
+                  </span>
+                </li>
+                <li
+                  className={`p-side-navigation__link ${isViewActive(VIEW_TREE) && "is-active"}`}
+                  onClick={() => changeView(VIEW_TREE)}
+                  style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+                >
+                  <span className="u-has-icon">
+                    <i className="p-icon--switcher-environments is-dark" />
+                    Tree view
+                  </span>
+
+                  {isViewActive(VIEW_TREE) && (
+                    <>
+                      <SiteSelector />
+                      <NavigationItems />
+                    </>
+                  )}
+                </li>
+              </ul>
+            </div>
+            <div style={{ marginTop: "2rem" }}>
+              <hr className="p-rule" />
+              <p className="p-muted-heading u-text--muted">Quick views</p>
+              <ul className="u-no-margin u-no-padding">
+                <li
+                  className={`p-side-navigation__link ${isViewActive(VIEW_OWNED) && "is-active"}`}
+                  onClick={() => changeView(VIEW_OWNED)}
+                >
+                  <span className="u-has-icon">
+                    <i className="p-icon--user" />
+                    Owned by me
+                  </span>
+                </li>
+                <li
+                  className={`p-side-navigation__link ${isViewActive(VIEW_REVIEWED) && "is-active"}`}
+                  onClick={() => changeView(VIEW_REVIEWED)}
+                >
+                  <span className="u-has-icon">
+                    <i className="p-icon--show" />
+                    Reviewed by me
+                  </span>
+                </li>
+              </ul>
             </div>
             <div className="p-panel__footer p-side-navigation--icons">
               <div className="u-no-margin u-truncate p-side-navigation__label">

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -20,8 +20,11 @@ const Navigation = (): JSX.Element => {
   const location = useLocation();
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [user, setUser] = useStore((state) => [state.user, state.setUser]);
-  const [view, setView] = useViewsStore((state) => [state.view, state.setView]);
-  const setExpandedProject = useViewsStore((state) => state.setExpandedProject);
+  const [view, setView, setExpandedProject] = useViewsStore((state) => [
+    state.view,
+    state.setView,
+    state.setExpandedProject,
+  ]);
 
   const logout = useCallback(() => {
     setUser({} as IUser);

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
@@ -9,5 +9,5 @@ export interface INavigationElementProps {
 
 export interface INavigationElementBadgeProps {
   page: IPage;
-  appearance?: string;
+  appearance?: "is-dark" | "is-light";
 }

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.types.ts
@@ -9,4 +9,5 @@ export interface INavigationElementProps {
 
 export interface INavigationElementBadgeProps {
   page: IPage;
+  appearance?: string;
 }

--- a/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
@@ -6,17 +6,17 @@ import type { INavigationElementBadgeProps } from "./NavigationElement.types";
 
 import { PageStatus } from "@/services/api/types/pages";
 
-const NavigationElementBadge = ({ page }: INavigationElementBadgeProps): JSX.Element => {
+const NavigationElementBadge = ({ page, appearance = "is-dark" }: INavigationElementBadgeProps): JSX.Element => {
   const getIcon = useMemo(() => {
     switch (page.status) {
       case PageStatus.NEW:
-        return <i className="p-icon--edit is-dark" />;
+        return <i className={`p-icon--edit ${appearance}`} />;
       case PageStatus.TO_DELETE:
-        return <i className="p-icon--archive is-dark" />;
+        return <i className={`p-icon--archive ${appearance}`} />;
       default:
         return <></>;
     }
-  }, [page.status]);
+  }, [appearance, page.status]);
 
   const getTitle = useMemo(() => {
     switch (page.status) {

--- a/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElementBadge.tsx
@@ -6,7 +6,7 @@ import type { INavigationElementBadgeProps } from "./NavigationElement.types";
 
 import { PageStatus } from "@/services/api/types/pages";
 
-const NavigationElementBadge = ({ page, appearance = "is-dark" }: INavigationElementBadgeProps): JSX.Element => {
+const NavigationElementBadge = ({ page, appearance }: INavigationElementBadgeProps): JSX.Element => {
   const getIcon = useMemo(() => {
     switch (page.status) {
       case PageStatus.NEW:

--- a/static/client/components/Navigation/_Navigation.scss
+++ b/static/client/components/Navigation/_Navigation.scss
@@ -29,6 +29,9 @@
       .l-site-selector,
       .l-site-selector__label,
       .l-new-webpage-button {
+        @media (max-width: $breakpoint-small) {
+          margin-top: 2rem;
+        }
         @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
           visibility: hidden;
         }
@@ -73,7 +76,7 @@
 
       .l-navigation-collapse-toggle {
         position: absolute;
-        right: 20px;
+        right: 0;
         top: 20px;
       }
     }
@@ -81,7 +84,11 @@
     .p-panel__content {
       max-height: calc(100vh - 540px);
       overflow: auto;
+      margin-bottom: 2rem;
 
+    }
+
+    .p-panel__content, .p-panel__views {
       @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
         visibility: hidden;
       }
@@ -111,6 +118,7 @@
   &:hover {
     @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
       .p-panel__content,
+      .p-panel__views,
       .p-panel__header .l-site-selector,
       .p-panel__header .l-site-selector__label,
       .p-panel__header .l-new-webpage-button {

--- a/static/client/components/Navigation/_Navigation.scss
+++ b/static/client/components/Navigation/_Navigation.scss
@@ -79,7 +79,7 @@
     }
 
     .p-panel__content {
-      height: calc(100vh - 440px);
+      max-height: calc(100vh - 540px);
       overflow: auto;
 
       @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
@@ -100,6 +100,11 @@
           left: 1rem;
         }
       }
+    }
+
+    li.p-side-navigation__link {
+      padding: 0.8rem 1rem;
+      cursor: pointer;
     }
   }
 

--- a/static/client/components/OwnerAndReviewers/Owner.tsx
+++ b/static/client/components/OwnerAndReviewers/Owner.tsx
@@ -4,8 +4,9 @@ import { useUsersRequest } from "./OwnerAndReviewers.hooks";
 import type { IOwnerAndReviewersProps } from "./OwnerAndReviewers.types";
 
 import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
+import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
+import config from "@/config";
 import { PagesServices } from "@/services/api/services/pages";
-import { getDefaultUser } from "@/services/api/services/users";
 import { type IUser } from "@/services/api/types/users";
 
 const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element => {
@@ -13,9 +14,12 @@ const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element =>
   const { options, setOptions, handleChange } = useUsersRequest();
 
   useEffect(() => {
-    let owner = page && page.owner ? page.owner : getDefaultUser();
-    setCurrentOwner(owner);
-    if (onSelectOwner) onSelectOwner(owner);
+    if (page) {
+      let owner = page.owner as IUser | null;
+      if (page.owner.name === "Default" || !page.owner.email) owner = null;
+      setCurrentOwner(owner);
+      if (onSelectOwner) onSelectOwner(owner);
+    }
   }, [onSelectOwner, page]);
 
   const handleRemoveOwner = useCallback(
@@ -43,7 +47,7 @@ const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element =>
 
   return (
     <CustomSearchAndFilter
-      label="Owner"
+      label={<IconTextWithTooltip icon="information" message={config.constants.ownerDef} text="Owner" />}
       onChange={handleChange}
       onRemove={handleRemoveOwner}
       onSelect={selectOwner}

--- a/static/client/components/OwnerAndReviewers/Owner.tsx
+++ b/static/client/components/OwnerAndReviewers/Owner.tsx
@@ -47,7 +47,7 @@ const Owner = ({ page, onSelectOwner }: IOwnerAndReviewersProps): JSX.Element =>
 
   return (
     <CustomSearchAndFilter
-      label={<IconTextWithTooltip icon="information" message={config.constants.ownerDef} text="Owner" />}
+      label={<IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} text="Owner" />}
       onChange={handleChange}
       onRemove={handleRemoveOwner}
       onSelect={selectOwner}

--- a/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
+++ b/static/client/components/OwnerAndReviewers/OwnerAndReviewers.types.ts
@@ -10,7 +10,7 @@ export interface IOwnerAndReviewersProps {
 }
 
 export interface ICustomSearchAndFilterProps {
-  label: string;
+  label: string | JSX.Element;
   options: IUser[];
   selectedOptions: IUser[];
   placeholder: string;

--- a/static/client/components/OwnerAndReviewers/Reviewers.tsx
+++ b/static/client/components/OwnerAndReviewers/Reviewers.tsx
@@ -4,6 +4,8 @@ import { useUsersRequest } from "./OwnerAndReviewers.hooks";
 import type { IOwnerAndReviewersProps } from "./OwnerAndReviewers.types";
 
 import CustomSearchAndFilter from "@/components/Common/CustomSearchAndFilter";
+import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
+import config from "@/config";
 import { PagesServices } from "@/services/api/services/pages";
 import { type IUser } from "@/services/api/types/users";
 
@@ -49,7 +51,7 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
 
   return (
     <CustomSearchAndFilter
-      label="Reviewers"
+      label={<IconTextWithTooltip icon="information" message={config.constants.reviewerDef} text="Reviewers" />}
       onChange={handleChange}
       onRemove={handleRemoveReviewer}
       onSelect={selectReviewer}

--- a/static/client/components/OwnerAndReviewers/Reviewers.tsx
+++ b/static/client/components/OwnerAndReviewers/Reviewers.tsx
@@ -51,7 +51,7 @@ const Reviewers = ({ page, onSelectReviewers }: IOwnerAndReviewersProps): JSX.El
 
   return (
     <CustomSearchAndFilter
-      label={<IconTextWithTooltip icon="information" message={config.constants.reviewerDef} text="Reviewers" />}
+      label={<IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} text="Reviewers" />}
       onChange={handleChange}
       onRemove={handleRemoveReviewer}
       onSelect={selectReviewer}

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -211,10 +211,9 @@ const RequestTaskModal = ({
                     <>
                       <span>Copy updates include:</span>
                       <ul className="u-no-margin">
-                        <li>Text changes to existing sections</li>
-                        <li>Adding a section that is a copy of an existing section, with different text</li>
-                        <li>Removing a section</li>
-                        <li>Replacing or removing logos or images</li>
+                        {config.tooltips.copyUpdates.map((item) => (
+                          <li>{item}</li>
+                        ))}
                       </ul>
                     </>
                   }
@@ -237,8 +236,9 @@ const RequestTaskModal = ({
                     <>
                       <span>Page refreshes include:</span>
                       <ul className="u-no-margin">
-                        <li>Changing or adding to the page layout</li>
-                        <li>Modifications that change the layout</li>
+                        {config.tooltips.pageRefreshes.map((item) => (
+                          <li>{item}</li>
+                        ))}
                       </ul>
                     </>
                   }

--- a/static/client/components/SiteSelector/SiteSelector.tsx
+++ b/static/client/components/SiteSelector/SiteSelector.tsx
@@ -1,45 +1,33 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 
 import { Select, Spinner } from "@canonical/react-components";
 import { useLocation } from "react-router-dom";
 
-import { usePages } from "@/services/api/hooks/pages";
-import { type IPagesResponse } from "@/services/api/types/pages";
+import { useProjects } from "@/services/api/hooks/projects";
 import { useStore } from "@/store";
 
 const SiteSelector = (): JSX.Element | null => {
   const location = useLocation();
-  const { data, isLoading } = usePages();
+  const { data: projects, isLoading } = useProjects();
 
   const [selectedProject, setSelectedProject] = useStore((state) => [state.selectedProject, state.setSelectedProject]);
 
-  const [projects, setProjects] = useState<IPagesResponse["data"][]>([]);
-
   // This hook presets the SiteSelector with a value, either from URL or just with the first option
   useEffect(() => {
-    if (projects.length && !selectedProject) {
+    if (projects?.length && !selectedProject) {
       // get project name from URL
       const match = location.pathname.match(/\/app\/webpage\/([^/]+)/);
       let projectFromURL;
       if (match) {
-        projectFromURL = projects.find((p) => p.name === match[1]);
+        projectFromURL = projects?.find((p) => p.name === match[1]);
       }
       setSelectedProject(projectFromURL || projects[0]);
     }
   }, [location, projects, selectedProject, setSelectedProject]);
 
-  // This hook sets a list of all projects
-  useEffect(() => {
-    // check that the data array actually has data in it
-    const hasData = data?.every((project) => project?.data);
-    if (!isLoading && data?.length && hasData && projects.length !== data.length) {
-      setProjects(data.map((project) => project.data));
-    }
-  }, [data, isLoading, projects]);
-
   const handleProjectChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const project = projects.find((p) => p.name === e.target.value);
+      const project = projects?.find((p) => p.name === e.target.value);
       if (project) {
         setSelectedProject(project);
       }
@@ -47,7 +35,7 @@ const SiteSelector = (): JSX.Element | null => {
     [projects, setSelectedProject],
   );
 
-  if (isLoading || !projects.length)
+  if (isLoading || !projects?.length)
     return (
       <>
         <Spinner />
@@ -58,10 +46,9 @@ const SiteSelector = (): JSX.Element | null => {
   return selectedProject ? (
     <Select
       className="l-site-selector"
-      label="Select Site"
       labelClassName="p-text--small-caps l-site-selector__label"
       onChange={handleProjectChange}
-      options={projects.map((project) => ({
+      options={projects?.map((project) => ({
         label: project.name,
         value: project.name,
       }))}

--- a/static/client/components/SiteSelector/SiteSelector.tsx
+++ b/static/client/components/SiteSelector/SiteSelector.tsx
@@ -38,8 +38,10 @@ const SiteSelector = (): JSX.Element | null => {
   if (isLoading || !projects?.length)
     return (
       <>
-        <Spinner />
-        <span>&nbsp;&nbsp;Loading...</span>
+        <span>
+          <Spinner />
+          &nbsp;&nbsp;Loading...
+        </span>
       </>
     );
 

--- a/static/client/components/Views/TableView/Products.tsx
+++ b/static/client/components/Views/TableView/Products.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+
+import { Button } from "@canonical/react-components";
+
+import type { IPage } from "@/services/api/types/pages";
+
+interface ProductsProps {
+  page: IPage;
+}
+
+const Products: React.FC<ProductsProps> = ({ page }) => {
+  const [showMore, setShowMore] = useState(false);
+
+  const toggleShowMore = () => {
+    setShowMore((prev) => !prev);
+  };
+
+  const getProducts = () => {
+    let products = page.products.map((product) => product.name);
+    if (products.length <= 3) {
+      return products.join(", ");
+    }
+    return (
+      <>
+        {showMore ? products.join(", ") : products.slice(0, 3).join(", ")}
+        <br />
+        <Button appearance="link" onClick={toggleShowMore}>
+          {showMore ? "Show less" : `Show ${products.length - 3} more`}
+        </Button>
+      </>
+    );
+  };
+
+  return <>{getProducts()}</>;
+};
+
+export default Products;

--- a/static/client/components/Views/TableView/Products.tsx
+++ b/static/client/components/Views/TableView/Products.tsx
@@ -16,7 +16,7 @@ const Products: React.FC<ProductsProps> = ({ page }) => {
   };
 
   const getProducts = () => {
-    let products = page.products.map((product) => product.name);
+    let products = page?.products?.map((product) => product.name) || [];
     if (products.length <= 3) {
       return products.join(", ");
     }

--- a/static/client/components/Views/TableView/ProjectContent.tsx
+++ b/static/client/components/Views/TableView/ProjectContent.tsx
@@ -14,7 +14,7 @@ const ProjectContent: React.FC<ProjectContentProps> = ({ project }) => {
     <table>
       <tbody>
         {!isFilterApplied && <TableViewRow page={project.templates} />}
-        {project.templates.children.map((page) => (
+        {project?.templates?.children?.map((page) => (
           <TableViewRowItem key={`${page.project?.name}${page.url}`} page={page} />
         ))}
       </tbody>

--- a/static/client/components/Views/TableView/ProjectContent.tsx
+++ b/static/client/components/Views/TableView/ProjectContent.tsx
@@ -1,0 +1,23 @@
+import TableViewRow from "./TableViewRow";
+import TableViewRowItem from "./TableViewRowItem";
+
+import type { IPagesResponse } from "@/services/api/types/pages";
+
+interface ProjectContentProps {
+  project: IPagesResponse["data"];
+}
+
+const ProjectContent: React.FC<ProjectContentProps> = ({ project }) => {
+  return (
+    <table>
+      <tbody>
+        <TableViewRow page={project.templates} />
+        {project.templates.children.map((page) => (
+          <TableViewRowItem key={page.url} page={page} />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default ProjectContent;

--- a/static/client/components/Views/TableView/ProjectContent.tsx
+++ b/static/client/components/Views/TableView/ProjectContent.tsx
@@ -15,7 +15,7 @@ const ProjectContent: React.FC<ProjectContentProps> = ({ project }) => {
       <tbody>
         {!isFilterApplied && <TableViewRow page={project.templates} />}
         {project.templates.children.map((page) => (
-          <TableViewRowItem key={page.url} page={page} />
+          <TableViewRowItem key={`${page.project?.name}${page.url}`} page={page} />
         ))}
       </tbody>
     </table>

--- a/static/client/components/Views/TableView/ProjectContent.tsx
+++ b/static/client/components/Views/TableView/ProjectContent.tsx
@@ -1,6 +1,7 @@
 import TableViewRow from "./TableViewRow";
 import TableViewRowItem from "./TableViewRowItem";
 
+import { useProjects } from "@/services/api/hooks/projects";
 import type { IPagesResponse } from "@/services/api/types/pages";
 
 interface ProjectContentProps {
@@ -8,10 +9,11 @@ interface ProjectContentProps {
 }
 
 const ProjectContent: React.FC<ProjectContentProps> = ({ project }) => {
+  const { isFilterApplied } = useProjects();
   return (
     <table>
       <tbody>
-        <TableViewRow page={project.templates} />
+        {!isFilterApplied && <TableViewRow page={project.templates} />}
         {project.templates.children.map((page) => (
           <TableViewRowItem key={page.url} page={page} />
         ))}

--- a/static/client/components/Views/TableView/ProjectTitle.tsx
+++ b/static/client/components/Views/TableView/ProjectTitle.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@canonical/react-components";
 
+import { useProjects } from "@/services/api/hooks/projects";
 import type { IPage, IPagesResponse } from "@/services/api/types/pages";
 
 interface ProjectTitleProps {
@@ -12,12 +13,13 @@ function countPages(page: IPage): number {
 }
 
 const ProjectTitle: React.FC<ProjectTitleProps> = ({ project }) => {
+  const { isFilterApplied } = useProjects();
   return (
     <span style={{ display: "inline-flex", alignItems: "baseline" }}>
       <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
         {project.name}
       </span>
-      <Badge value={countPages(project.templates)} />
+      <Badge value={countPages(project.templates) - (isFilterApplied ? 1 : 0)} />
     </span>
   );
 };

--- a/static/client/components/Views/TableView/ProjectTitle.tsx
+++ b/static/client/components/Views/TableView/ProjectTitle.tsx
@@ -1,0 +1,25 @@
+import { Badge } from "@canonical/react-components";
+
+import type { IPage, IPagesResponse } from "@/services/api/types/pages";
+
+interface ProjectTitleProps {
+  project: IPagesResponse["data"];
+}
+
+function countPages(page: IPage): number {
+  if (!page) return 0;
+  return 1 + page.children?.reduce((acc, child) => acc + countPages(child), 0);
+}
+
+const ProjectTitle: React.FC<ProjectTitleProps> = ({ project }) => {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "baseline" }}>
+      <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
+        {project.name}
+      </span>
+      <Badge value={countPages(project.templates)} />
+    </span>
+  );
+};
+
+export default ProjectTitle;

--- a/static/client/components/Views/TableView/ProjectTitle.tsx
+++ b/static/client/components/Views/TableView/ProjectTitle.tsx
@@ -15,11 +15,11 @@ function countPages(page: IPage): number {
 const ProjectTitle: React.FC<ProjectTitleProps> = ({ project }) => {
   const { isFilterApplied } = useProjects();
   return (
-    <span style={{ display: "inline-flex", alignItems: "baseline" }}>
+    <span className="u-sv1">
       <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
         {project.name}
       </span>
-      <Badge value={countPages(project.templates) - (isFilterApplied ? 1 : 0)} />
+      <Badge className="u-no-padding--top" value={countPages(project.templates) - (isFilterApplied ? 1 : 0)} />
     </span>
   );
 };

--- a/static/client/components/Views/TableView/Reviewers.tsx
+++ b/static/client/components/Views/TableView/Reviewers.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+
+import { Button } from "@canonical/react-components";
+
+import type { IPage } from "@/services/api/types/pages";
+
+interface ReviewersProps {
+  page: IPage;
+}
+
+const Reviewers: React.FC<ReviewersProps> = ({ page }) => {
+  const [showMore, setShowMore] = useState(false);
+
+  const toggleShowMore = () => {
+    setShowMore((prev) => !prev);
+  };
+
+  const getReviewers = () => {
+    let reviewers = page.reviewers.map((reviewer) => reviewer.name);
+    if (reviewers.length <= 2) {
+      return reviewers.join(", ");
+    }
+    return (
+      <>
+        {showMore ? reviewers.join(", ") : reviewers.slice(0, 2).join(", ")}
+        <br />
+        <Button appearance="link" onClick={toggleShowMore}>
+          {showMore ? "Show less" : `Show ${reviewers.length - 2} more`}
+        </Button>
+      </>
+    );
+  };
+
+  return <>{getReviewers()}</>;
+};
+
+export default Reviewers;

--- a/static/client/components/Views/TableView/Reviewers.tsx
+++ b/static/client/components/Views/TableView/Reviewers.tsx
@@ -16,7 +16,7 @@ const Reviewers: React.FC<ReviewersProps> = ({ page }) => {
   };
 
   const getReviewers = () => {
-    let reviewers = page.reviewers.map((reviewer) => reviewer.name);
+    let reviewers = page?.reviewers?.map((reviewer) => reviewer.name) || [];
     if (reviewers.length <= 2) {
       return reviewers.join(", ");
     }

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -11,7 +11,7 @@ import { useProjects } from "@/services/api/hooks/projects";
 import { useViewsStore } from "@/store/views";
 
 const TableView: React.FC = () => {
-  const { data: projects } = useProjects();
+  const { data: projects, isLoading } = useProjects();
   const [view, setView, setFilter] = useViewsStore((state) => [state.view, state.setView, state.setFilter]);
   const [expandedProject, setExpandedProject] = useViewsStore((state) => [
     state.expandedProject,
@@ -72,6 +72,15 @@ const TableView: React.FC = () => {
           </tr>
         </thead>
       </table>
+
+      {(isLoading || !projects.length) && (
+        <>
+          <span className="u-has-icon">
+            <i className="p-icon--spinner u-animation--spin"></i>
+            Loading projects. Please wait.
+          </span>
+        </>
+      )}
 
       <Accordion expanded={expandedProject} onExpandedChange={setExpandedProject} sections={getAccordionSections} />
     </>

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+import { Accordion, Badge, Tooltip } from "@canonical/react-components";
+
+import TableViewRowItem from "@/components/Views/TableView/TableViewRowItem";
+import { useProjects } from "@/services/api/hooks/projects";
+import type { IPage, IPagesResponse } from "@/services/api/types/pages";
+
+const TableView: React.FC = () => {
+  const { data: projects } = useProjects();
+
+  function getAccordionSections() {
+    let sections = [];
+    if (projects?.length) {
+      for (const project of projects) {
+        sections.push({
+          title: getAccordionTitle(project),
+          content: getAccordionContent(project),
+        });
+      }
+    }
+    return sections;
+  }
+
+  function getAccordionTitle(project: IPagesResponse["data"]) {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "baseline" }}>
+        <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
+          {project.name}
+        </span>
+        <Badge value={getAccordionBadgeCount(project)} />
+      </span>
+    );
+  }
+
+  function getAccordionBadgeCount(project: IPagesResponse["data"]) {
+    function countPages(page: IPage): number {
+      if (!page) return 0;
+      return 1 + page.children?.reduce((acc, child) => acc + countPages(child), 0);
+    }
+
+    return countPages(project.templates);
+  }
+
+  function getAccordionContent(project: IPagesResponse["data"]) {
+    return (
+      <table>
+        <tbody>
+          <TableViewRowItem key={project.name} page={project.templates} />
+          {project.templates.children.map((page) => (
+            <TableViewRowItem key={page.url} page={page} />
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr style={{ borderBottom: "none" }}>
+            <th>Url</th>
+            <th>
+              <Tooltip message="Owners request the page and must approve the page for it to go live." zIndex={999}>
+                Owner&nbsp;
+                <i className="p-icon--information" />
+              </Tooltip>
+            </th>
+            <th>
+              <Tooltip
+                message="Reviewers can contribute to page content, but they can't approve the page to go live."
+                zIndex={999}
+              >
+                Reviewers&nbsp;
+                <i className="p-icon--information" />
+              </Tooltip>
+            </th>
+            <th>Products</th>
+          </tr>
+        </thead>
+      </table>
+
+      <Accordion sections={getAccordionSections()} />
+    </>
+  );
+};
+
+export default TableView;

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -1,14 +1,19 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 
 import { Accordion, Tooltip } from "@canonical/react-components";
+import { useLocation } from "react-router-dom";
 
 import ProjectContent from "./ProjectContent";
 import ProjectTitle from "./ProjectTitle";
 
+import { VIEW_TABLE, VIEW_TREE } from "@/config";
 import { useProjects } from "@/services/api/hooks/projects";
+import { useViewsStore } from "@/store/views";
 
 const TableView: React.FC = () => {
   const { data: projects } = useProjects();
+  const [view, setView, setFilter] = useViewsStore((state) => [state.view, state.setView, state.setFilter]);
+  const location = useLocation();
 
   const getAccordionSections = useMemo(() => {
     if (!projects?.length) return [];
@@ -17,6 +22,18 @@ const TableView: React.FC = () => {
       content: <ProjectContent project={project} />,
     }));
   }, [projects]);
+
+  useEffect(() => {
+    if (location.pathname === "/app") {
+      if (view !== VIEW_TREE) setView(VIEW_TABLE);
+      setFilter({
+        owners: [],
+        reviewers: [],
+        products: [],
+        query: "",
+      });
+    }
+  }, [location.pathname, setFilter, setView, view]);
 
   return (
     <>

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -13,11 +13,23 @@ import { useViewsStore } from "@/store/views";
 const TableView: React.FC = () => {
   const { data: projects } = useProjects();
   const [view, setView, setFilter] = useViewsStore((state) => [state.view, state.setView, state.setFilter]);
+  const [expandedProject, setExpandedProject] = useViewsStore((state) => [
+    state.expandedProject,
+    state.setExpandedProject,
+  ]);
+
+  useEffect(() => {
+    if (expandedProject) {
+      setExpandedProject(expandedProject);
+    }
+  }, [expandedProject, setExpandedProject]);
+
   const location = useLocation();
 
   const getAccordionSections = useMemo(() => {
     if (!projects?.length) return [];
     return projects.map((project) => ({
+      key: project.name,
       title: <ProjectTitle project={project} />,
       content: <ProjectContent project={project} />,
     }));
@@ -61,7 +73,7 @@ const TableView: React.FC = () => {
         </thead>
       </table>
 
-      <Accordion sections={getAccordionSections} />
+      <Accordion expanded={expandedProject} onExpandedChange={setExpandedProject} sections={getAccordionSections} />
     </>
   );
 };

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -6,7 +6,8 @@ import { useLocation } from "react-router-dom";
 import ProjectContent from "./ProjectContent";
 import ProjectTitle from "./ProjectTitle";
 
-import { VIEW_TABLE, VIEW_TREE } from "@/config";
+import IconTextWithTooltip from "@/components/Common/IconTextWithTooltip";
+import config, { VIEW_TABLE, VIEW_TREE } from "@/config";
 import { useProjects } from "@/services/api/hooks/projects";
 import { useViewsStore } from "@/store/views";
 
@@ -54,19 +55,10 @@ const TableView: React.FC = () => {
           <tr style={{ borderBottom: "none" }}>
             <th>Url</th>
             <th>
-              <Tooltip message="Owners request the page and must approve the page for it to go live." zIndex={999}>
-                Owner&nbsp;
-                <i className="p-icon--information" />
-              </Tooltip>
+              <IconTextWithTooltip icon="information" message={config.constants.ownerDef} text="Owner" />
             </th>
             <th>
-              <Tooltip
-                message="Reviewers can contribute to page content, but they can't approve the page to go live."
-                zIndex={999}
-              >
-                Reviewers&nbsp;
-                <i className="p-icon--information" />
-              </Tooltip>
+              <IconTextWithTooltip icon="information" message={config.constants.reviewerDef} text="Reviewers" />
             </th>
             <th>Products</th>
           </tr>

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from "react";
 
-import { Accordion, Tooltip } from "@canonical/react-components";
+import { Accordion, Spinner } from "@canonical/react-components";
 import { useLocation } from "react-router-dom";
 
 import ProjectContent from "./ProjectContent";
@@ -13,17 +13,13 @@ import { useViewsStore } from "@/store/views";
 
 const TableView: React.FC = () => {
   const { data: projects, isLoading } = useProjects();
-  const [view, setView, setFilter] = useViewsStore((state) => [state.view, state.setView, state.setFilter]);
-  const [expandedProject, setExpandedProject] = useViewsStore((state) => [
+  const [view, setView, setFilter, expandedProject, setExpandedProject] = useViewsStore((state) => [
+    state.view,
+    state.setView,
+    state.setFilter,
     state.expandedProject,
     state.setExpandedProject,
   ]);
-
-  useEffect(() => {
-    if (expandedProject) {
-      setExpandedProject(expandedProject);
-    }
-  }, [expandedProject, setExpandedProject]);
 
   const location = useLocation();
 
@@ -55,26 +51,21 @@ const TableView: React.FC = () => {
           <tr style={{ borderBottom: "none" }}>
             <th>Url</th>
             <th>
-              <IconTextWithTooltip icon="information" message={config.constants.ownerDef} text="Owner" />
+              <IconTextWithTooltip icon="information" message={config.tooltips.ownerDef} text="Owner" />
             </th>
             <th>
-              <IconTextWithTooltip icon="information" message={config.constants.reviewerDef} text="Reviewers" />
+              <IconTextWithTooltip icon="information" message={config.tooltips.reviewerDef} text="Reviewers" />
             </th>
             <th>Products</th>
           </tr>
         </thead>
       </table>
 
-      {(isLoading || !projects.length) && (
-        <>
-          <span className="u-has-icon">
-            <i className="p-icon--spinner u-animation--spin"></i>
-            Loading projects. Please wait.
-          </span>
-        </>
-      )}
+      {(isLoading || !projects.length) && <Spinner text="Loading projects. Please wait." />}
 
-      <Accordion expanded={expandedProject} onExpandedChange={setExpandedProject} sections={getAccordionSections} />
+      {!isLoading && (
+        <Accordion expanded={expandedProject} onExpandedChange={setExpandedProject} sections={getAccordionSections} />
+      )}
     </>
   );
 };

--- a/static/client/components/Views/TableView/TableView.tsx
+++ b/static/client/components/Views/TableView/TableView.tsx
@@ -1,56 +1,22 @@
 import React, { useMemo } from "react";
 
-import { Accordion, Badge, Tooltip } from "@canonical/react-components";
+import { Accordion, Tooltip } from "@canonical/react-components";
 
-import TableViewRow from "./TableViewRow";
+import ProjectContent from "./ProjectContent";
+import ProjectTitle from "./ProjectTitle";
 
-import TableViewRowItem from "@/components/Views/TableView/TableViewRowItem";
 import { useProjects } from "@/services/api/hooks/projects";
-import type { IPage, IPagesResponse } from "@/services/api/types/pages";
 
 const TableView: React.FC = () => {
   const { data: projects } = useProjects();
 
-  const getAccordionBadgeCount = useMemo(() => {
-    function countPages(page: IPage): number {
-      if (!page) return 0;
-      return 1 + page.children?.reduce((acc, child) => acc + countPages(child), 0);
-    }
-
-    return (project: IPagesResponse["data"]) => countPages(project.templates);
-  }, []);
-
-  const getAccordionTitle = useMemo(() => {
-    return (project: IPagesResponse["data"]) => (
-      <span style={{ display: "inline-flex", alignItems: "baseline" }}>
-        <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
-          {project.name}
-        </span>
-        <Badge value={getAccordionBadgeCount(project)} />
-      </span>
-    );
-  }, [getAccordionBadgeCount]);
-
-  const getAccordionContent = useMemo(() => {
-    return (project: IPagesResponse["data"]) => (
-      <table>
-        <tbody>
-          <TableViewRow page={project.templates} />
-          {project.templates.children.map((page) => (
-            <TableViewRowItem key={page.url} page={page} />
-          ))}
-        </tbody>
-      </table>
-    );
-  }, []);
-
   const getAccordionSections = useMemo(() => {
     if (!projects?.length) return [];
     return projects.map((project) => ({
-      title: getAccordionTitle(project),
-      content: getAccordionContent(project),
+      title: <ProjectTitle project={project} />,
+      content: <ProjectContent project={project} />,
     }));
-  }, [projects, getAccordionTitle, getAccordionContent]);
+  }, [projects]);
 
   return (
     <>

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -16,17 +16,20 @@ interface TableViewRowProps {
 const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
   const navigate = useNavigate();
 
-  function onPageSelect(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, page: IPage) {
-    e.stopPropagation();
-    e.preventDefault();
-    navigate(`/app/webpage/${page.project?.name}${page.url}`);
-  }
+  const onPageSelect = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, page: IPage) => {
+      e.stopPropagation();
+      e.preventDefault();
+      navigate(`/app/webpage/${page.project?.name}${page.url}`);
+    },
+    [navigate],
+  );
 
   return (
     <tr data-id={page.id} data-parent-id={page.parent_id} id={`${page?.project?.name}${page.url}`}>
       <td>
         <span className="u-has-icon">
-          <NavigationElementBadge appearance="" page={page} />
+          <NavigationElementBadge page={page} />
           <Button
             appearance="link"
             className="u-no-margin--bottom u-no-padding u-align-text--left"

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -27,7 +27,11 @@ const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
       <td>
         <span className="u-has-icon">
           <NavigationElementBadge appearance="" page={page} />
-          <Button appearance="link" className="u-no-margin--bottom u-no-padding" onClick={(e) => onPageSelect(e, page)}>
+          <Button
+            appearance="link"
+            className="u-no-margin--bottom u-no-padding u-align-text--left"
+            onClick={(e) => onPageSelect(e, page)}
+          >
             {page.url || "/"}
           </Button>
         </span>

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -27,7 +27,7 @@ const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
       <td>
         <span className="u-has-icon">
           <NavigationElementBadge appearance="" page={page} />
-          <Button appearance="link" onClick={(e) => onPageSelect(e, page)}>
+          <Button appearance="link" className="u-no-margin--bottom u-no-padding" onClick={(e) => onPageSelect(e, page)}>
             {page.url || "/"}
           </Button>
         </span>

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { Button } from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+
+import Products from "./Products";
+import Reviewers from "./Reviewers";
+
+import NavigationElementBadge from "@/components/Navigation/NavigationElement/NavigationElementBadge";
+import type { IPage } from "@/services/api/types/pages";
+
+interface TableViewRowProps {
+  page: IPage;
+}
+
+const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
+  const navigate = useNavigate();
+
+  function onPageSelect(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, page: IPage) {
+    e.stopPropagation();
+    e.preventDefault();
+    navigate(`/app/webpage/${page.project?.name}${page.url}`);
+  }
+
+  return (
+    <tr data-id={page.id} data-parent-id={page.parent_id}>
+      <td>
+        <span className="u-has-icon">
+          <NavigationElementBadge appearance="" page={page} />
+          <Button appearance="link" onClick={(e) => onPageSelect(e, page)}>
+            {page.url || "/"}
+          </Button>
+        </span>
+      </td>
+      <td>{page.owner?.name}</td>
+      <td>
+        <Reviewers page={page} />
+      </td>
+      <td>
+        <Products page={page} />
+      </td>
+    </tr>
+  );
+};
+
+export default TableViewRow;

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -32,7 +32,7 @@ const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
           </Button>
         </span>
       </td>
-      <td>{page.owner?.name}</td>
+      <td>{!(page.owner?.name === "Default" || !page.owner?.email) && page.owner?.name}</td>
       <td>
         <Reviewers page={page} />
       </td>

--- a/static/client/components/Views/TableView/TableViewRow.tsx
+++ b/static/client/components/Views/TableView/TableViewRow.tsx
@@ -23,7 +23,7 @@ const TableViewRow: React.FC<TableViewRowProps> = ({ page }) => {
   }
 
   return (
-    <tr data-id={page.id} data-parent-id={page.parent_id}>
+    <tr data-id={page.id} data-parent-id={page.parent_id} id={`${page?.project?.name}${page.url}`}>
       <td>
         <span className="u-has-icon">
           <NavigationElementBadge appearance="" page={page} />

--- a/static/client/components/Views/TableView/TableViewRowItem.tsx
+++ b/static/client/components/Views/TableView/TableViewRowItem.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+import { Button } from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+
+import NavigationElementBadge from "@/components/Navigation/NavigationElement/NavigationElementBadge";
+import type { IPage } from "@/services/api/types/pages";
+
+interface TableViewRowItemProps {
+  page: IPage;
+}
+
+const TableViewRowItem: React.FC<TableViewRowItemProps> = ({ page }) => {
+  const navigate = useNavigate();
+
+  function onPageSelect(e, page: IPage) {
+    e.stopPropagation();
+    e.preventDefault();
+    navigate(`/app/webpage/${page.project?.name}${page.url}`);
+  }
+
+  function getReviewers(page: IPage) {
+    let reviewers = page.reviewers.map((reviewer) => reviewer.name);
+    return reviewers.join(", ");
+  }
+
+  function getProducts(page: IPage) {
+    return page.products.map((product) => product.name).join(", ");
+  }
+
+  return (
+    <>
+      <tr data-id={page.id} data-parent-id={page.parent_id}>
+        <td>
+          <NavigationElementBadge appearance="" page={page} />
+          <span style={{ marginLeft: "0.5rem" }}>
+            <Button appearance="link" onClick={(e) => onPageSelect(e, page)}>
+              {page.url || "/"}
+            </Button>
+          </span>
+        </td>
+        <td>{page.owner?.name}</td>
+        <td>{getReviewers(page)}</td>
+        <td>{getProducts(page)}</td>
+      </tr>
+      {page.children.map((child) => {
+        return <TableViewRowItem key={child.url} page={child} />;
+      })}
+    </>
+  );
+};
+
+export default TableViewRowItem;

--- a/static/client/components/Views/TableView/TableViewRowItem.tsx
+++ b/static/client/components/Views/TableView/TableViewRowItem.tsx
@@ -13,7 +13,7 @@ const TableViewRowItem: React.FC<TableViewRowItemProps> = ({ page }) => {
     <>
       <TableViewRow page={page} />
       {page.children.map((child) => {
-        return <TableViewRowItem key={child.url} page={child} />;
+        return <TableViewRowItem key={`${child.project?.name}${child.url}`} page={child} />;
       })}
     </>
   );

--- a/static/client/components/Views/TableView/TableViewRowItem.tsx
+++ b/static/client/components/Views/TableView/TableViewRowItem.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
-import { Button } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom";
+import TableViewRow from "./TableViewRow";
 
-import NavigationElementBadge from "@/components/Navigation/NavigationElement/NavigationElementBadge";
 import type { IPage } from "@/services/api/types/pages";
 
 interface TableViewRowItemProps {
@@ -11,38 +9,9 @@ interface TableViewRowItemProps {
 }
 
 const TableViewRowItem: React.FC<TableViewRowItemProps> = ({ page }) => {
-  const navigate = useNavigate();
-
-  function onPageSelect(e, page: IPage) {
-    e.stopPropagation();
-    e.preventDefault();
-    navigate(`/app/webpage/${page.project?.name}${page.url}`);
-  }
-
-  function getReviewers(page: IPage) {
-    let reviewers = page.reviewers.map((reviewer) => reviewer.name);
-    return reviewers.join(", ");
-  }
-
-  function getProducts(page: IPage) {
-    return page.products.map((product) => product.name).join(", ");
-  }
-
   return (
     <>
-      <tr data-id={page.id} data-parent-id={page.parent_id}>
-        <td>
-          <NavigationElementBadge appearance="" page={page} />
-          <span style={{ marginLeft: "0.5rem" }}>
-            <Button appearance="link" onClick={(e) => onPageSelect(e, page)}>
-              {page.url || "/"}
-            </Button>
-          </span>
-        </td>
-        <td>{page.owner?.name}</td>
-        <td>{getReviewers(page)}</td>
-        <td>{getProducts(page)}</td>
-      </tr>
+      <TableViewRow page={page} />
       {page.children.map((child) => {
         return <TableViewRowItem key={child.url} page={child} />;
       })}

--- a/static/client/components/Views/TableView/TableViewRowItem.tsx
+++ b/static/client/components/Views/TableView/TableViewRowItem.tsx
@@ -12,7 +12,7 @@ const TableViewRowItem: React.FC<TableViewRowItemProps> = ({ page }) => {
   return (
     <>
       <TableViewRow page={page} />
-      {page.children.map((child) => {
+      {page?.children?.map((child) => {
         return <TableViewRowItem key={`${child.project?.name}${child.url}`} page={child} />;
       })}
     </>

--- a/static/client/components/Views/TableView/index.ts
+++ b/static/client/components/Views/TableView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TableView";

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -1,7 +1,15 @@
+import type { TView } from "@/services/api/types/views";
+
 let staleTime = process.env.NODE_ENV === "production" ? 300000 : 30000;
+
+export const VIEW_OWNED = "owned";
+export const VIEW_REVIEWED = "reviewed";
+export const VIEW_TREE = "tree";
+export const VIEW_TABLE = "table";
 
 const config = {
   projects: ["canonical.com", "ubuntu.com", "cn.ubuntu.com", "jp.ubuntu.com"],
+  views: [VIEW_OWNED, VIEW_REVIEWED, VIEW_TREE, VIEW_TABLE] as TView[],
   api: {
     path: "/",
     FETCH_OPTIONS: {

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -10,9 +10,16 @@ export const VIEW_TABLE = "table";
 const config = {
   projects: ["canonical.com", "ubuntu.com", "cn.ubuntu.com", "jp.ubuntu.com"],
   views: [VIEW_OWNED, VIEW_REVIEWED, VIEW_TREE, VIEW_TABLE] as TView[],
-  constants: {
+  tooltips: {
     ownerDef: "Owners request the page and must approve the page for it to go live.",
     reviewerDef: "Reviewers can contribute to page content, but they can't approve the page to go live.",
+    copyUpdates: [
+      "Text changes to existing sections",
+      "Adding a section that is a copy of an existing section, with different text",
+      "Removing a section",
+      "Replacing or removing logos or images",
+    ],
+    pageRefreshes: ["Changing or adding to the page layout", "Modifications that change the layout"],
   },
   api: {
     path: "/",

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -10,6 +10,10 @@ export const VIEW_TABLE = "table";
 const config = {
   projects: ["canonical.com", "ubuntu.com", "cn.ubuntu.com", "jp.ubuntu.com"],
   views: [VIEW_OWNED, VIEW_REVIEWED, VIEW_TREE, VIEW_TABLE] as TView[],
+  constants: {
+    ownerDef: "Owners request the page and must approve the page for it to go live.",
+    reviewerDef: "Reviewers can contribute to page content, but they can't approve the page to go live.",
+  },
   api: {
     path: "/",
     FETCH_OPTIONS: {

--- a/static/client/helpers/views.ts
+++ b/static/client/helpers/views.ts
@@ -1,0 +1,27 @@
+import type { NavigateFunction, Location } from "react-router-dom";
+
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const flashRowTwice = (row: HTMLElement) => {
+  let toggles = 0;
+
+  const interval = setInterval(() => {
+    row.classList.toggle("p-table__row--highlight");
+    if (++toggles === 4) {
+      clearInterval(interval);
+      row.classList.remove("p-table__row--highlight");
+    }
+  }, 300);
+};
+
+export const goBack = (location: Location, navigate: NavigateFunction) => {
+  let hash = location.pathname.split("/webpage/")[1].replaceAll(".", "\\.").replaceAll("/", "\\/");
+  navigate(-1);
+  sleep(10).then(() => {
+    let selectedRow = document.querySelector(`#${hash}`) as HTMLElement;
+    if (selectedRow) {
+      selectedRow.scrollIntoView({ behavior: "smooth", block: "center" });
+      flashRowTwice(selectedRow);
+    }
+  });
+};

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import MainLayout from "@/components/MainLayout";
+import Owned from "@/pages/views/Owned";
+import Reviewed from "@/pages/views/Reviewed";
 import { useAuth } from "@/services/api/hooks/auth";
 import { usePages } from "@/services/api/hooks/pages";
 import { RoutesServices } from "@/services/routes";
@@ -12,7 +14,10 @@ const Main = (): React.ReactNode => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<MainLayout />} path="/app" />
+        <Route element={<MainLayout />} path="/app">
+          <Route element={<Owned />} path="views/owned" />
+          <Route element={<Reviewed />} path="views/reviewed" />
+        </Route>
         <Route element={<Navigate to="/app" />} path="/" />
         {data?.length &&
           data.map(

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -4,6 +4,7 @@ import { Button } from "@canonical/react-components";
 
 import { type IWebpageProps } from "./Webpage.types";
 
+import Breadcrumbs from "@/components/Breadcrumbs";
 import JiraTasks from "@/components/JiraTasks";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
 import Products from "@/components/Products";
@@ -54,15 +55,15 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
 
   return (
     <div className="l-webpage">
+      <div className="p-section--shallow">
+        <Breadcrumbs />
+      </div>
       {isNew ? (
         <h1>New page: {pageName}</h1>
       ) : (
         <>
-          <p className="p-text--small-caps" id="page-title">
-            Title
-          </p>
           <h1 aria-labelledby="page-title" className="u-no-padding--top">
-            {page.title || "-"}
+            {page.title || "No title"}
           </h1>
         </>
       )}

--- a/static/client/pages/views/Owned.tsx
+++ b/static/client/pages/views/Owned.tsx
@@ -13,6 +13,9 @@ const Owned: React.FC = () => {
     setView(VIEW_OWNED);
     setFilter({
       owners: [user.email],
+      reviewers: [],
+      products: [],
+      query: "",
     });
   }, [setFilter, setView, user.email]);
 

--- a/static/client/pages/views/Owned.tsx
+++ b/static/client/pages/views/Owned.tsx
@@ -1,8 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import TableView from "@/components/Views/TableView";
+import { VIEW_OWNED } from "@/config";
+import { useStore } from "@/store";
+import { useViewsStore } from "@/store/views";
 
 const Owned: React.FC = () => {
+  const [setView, setFilter] = useViewsStore((state) => [state.setView, state.setFilter]);
+  const user = useStore((state) => state.user);
+
+  useEffect(() => {
+    setView(VIEW_OWNED);
+    setFilter({
+      owners: [user.email],
+    });
+  }, [setFilter, setView, user.email]);
+
   return (
     <div className="l-owned-view-page">
       <h2>Owned by me</h2>

--- a/static/client/pages/views/Owned.tsx
+++ b/static/client/pages/views/Owned.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import TableView from "@/components/Views/TableView";
+
+const Owned: React.FC = () => {
+  return (
+    <div className="l-owned-view-page">
+      <h2>Owned by me</h2>
+      <TableView />
+    </div>
+  );
+};
+
+export default Owned;

--- a/static/client/pages/views/Reviewed.tsx
+++ b/static/client/pages/views/Reviewed.tsx
@@ -12,7 +12,10 @@ const Reviewed: React.FC = () => {
   useEffect(() => {
     setView(VIEW_REVIEWED);
     setFilter({
+      owners: [],
       reviewers: [user.email],
+      products: [],
+      query: "",
     });
   }, [setFilter, setView, user.email]);
 

--- a/static/client/pages/views/Reviewed.tsx
+++ b/static/client/pages/views/Reviewed.tsx
@@ -1,8 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import TableView from "@/components/Views/TableView";
+import { VIEW_REVIEWED } from "@/config";
+import { useStore } from "@/store";
+import { useViewsStore } from "@/store/views";
 
 const Reviewed: React.FC = () => {
+  const [setView, setFilter] = useViewsStore((state) => [state.setView, state.setFilter]);
+  const user = useStore((state) => state.user);
+
+  useEffect(() => {
+    setView(VIEW_REVIEWED);
+    setFilter({
+      reviewers: [user.email],
+    });
+  }, [setFilter, setView, user.email]);
+
   return (
     <div className="l-reviwed-view-page">
       <h2>Reviewed by me</h2>

--- a/static/client/pages/views/Reviewed.tsx
+++ b/static/client/pages/views/Reviewed.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import TableView from "@/components/Views/TableView";
+
+const Reviewed: React.FC = () => {
+  return (
+    <div className="l-reviwed-view-page">
+      <h2>Reviewed by me</h2>
+      <TableView />
+    </div>
+  );
+};
+
+export default Reviewed;

--- a/static/client/services/api/hooks/projects.ts
+++ b/static/client/services/api/hooks/projects.ts
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+import { usePages } from "./pages";
+
+import type { IPagesResponse } from "@/services/api/types/pages";
+import type { IUseQueryHookRest } from "@/services/api/types/query";
+
+export function useProjects(): IUseQueryHookRest<IPagesResponse["data"][]> {
+  const { data, isLoading } = usePages();
+
+  const [projects, setProjects] = useState<IPagesResponse["data"][]>([]);
+
+  const hasData = data?.every((project) => project?.data);
+  if (!isLoading && data?.length && hasData && projects.length !== data.length) {
+    setProjects(data.map((project) => project.data));
+  }
+
+  return { data: projects, error: null, isLoading };
+}

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -28,6 +28,14 @@ export interface IPage {
   jira_tasks: IJiraTask[];
   children: IPage[];
   products: IProduct[];
+  parent_id?: number;
+  url?: string;
+  project?: {
+    created_at: string;
+    id: number;
+    name: string;
+    updated_at: string;
+  };
 }
 
 export interface IPagesResponse {

--- a/static/client/services/api/types/views.ts
+++ b/static/client/services/api/types/views.ts
@@ -1,3 +1,10 @@
 import type { VIEW_OWNED, VIEW_REVIEWED, VIEW_TABLE, VIEW_TREE } from "@/config";
 
 export type TView = typeof VIEW_OWNED | typeof VIEW_REVIEWED | typeof VIEW_TREE | typeof VIEW_TABLE;
+
+export interface IViewFilter {
+  owners: string[];
+  reviewers: string[];
+  products: string[];
+  query: string | null;
+}

--- a/static/client/services/api/types/views.ts
+++ b/static/client/services/api/types/views.ts
@@ -1,0 +1,3 @@
+import type { VIEW_OWNED, VIEW_REVIEWED, VIEW_TABLE, VIEW_TREE } from "@/config";
+
+export type TView = typeof VIEW_OWNED | typeof VIEW_REVIEWED | typeof VIEW_TREE | typeof VIEW_TABLE;

--- a/static/client/store/types.ts
+++ b/static/client/store/types.ts
@@ -1,9 +1,17 @@
 import { type IPagesResponse } from "@/services/api/types/pages";
 import { type IUser } from "@/services/api/types/users";
+import type { IViewFilter, TView } from "@/services/api/types/views";
 
 export interface IStore {
   selectedProject: IPagesResponse["data"] | null;
   user: IUser;
   setSelectedProject: (s: IPagesResponse["data"]) => void;
   setUser: (u: IUser) => void;
+}
+
+export interface IViewsStore {
+  view: TView;
+  filter: IViewFilter;
+  setView: (s: TView) => void;
+  setFilter: (s: Partial<IViewFilter>) => void;
 }

--- a/static/client/store/types.ts
+++ b/static/client/store/types.ts
@@ -14,4 +14,6 @@ export interface IViewsStore {
   filter: IViewFilter;
   setView: (s: TView) => void;
   setFilter: (s: Partial<IViewFilter>) => void;
+  expandedProject: string;
+  setExpandedProject: (s: IViewsStore["expandedProject"]) => void;
 }

--- a/static/client/store/views.ts
+++ b/static/client/store/views.ts
@@ -1,15 +1,30 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
-import type { TView } from "@/services/api/types/views";
+import type { IViewsStore } from "./types";
 
-export const useViewsStore = create<any>()(
+import { VIEW_TABLE } from "@/config";
+import type { IViewFilter, TView } from "@/services/api/types/views";
+
+export const useViewsStore = create<IViewsStore>()(
   devtools(
     persist(
       (set) => ({
-        view: null,
-        filters: null,
+        view: VIEW_TABLE as TView,
+        filter: {
+          owners: [],
+          reviewers: [],
+          products: [],
+          query: null,
+        } as IViewFilter,
         setView: (s: TView) => set({ view: s }),
+        setFilter: (s: Partial<IViewFilter>) =>
+          set((state: IViewsStore) => ({
+            filter: {
+              ...state.filter,
+              ...s,
+            },
+          })),
       }),
       {
         name: "viewsStore",

--- a/static/client/store/views.ts
+++ b/static/client/store/views.ts
@@ -25,6 +25,8 @@ export const useViewsStore = create<IViewsStore>()(
               ...s,
             },
           })),
+        expandedProject: "",
+        setExpandedProject: (s: string) => set({ expandedProject: s }),
       }),
       {
         name: "viewsStore",

--- a/static/client/store/views.ts
+++ b/static/client/store/views.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { devtools, persist } from "zustand/middleware";
+
+import type { TView } from "@/services/api/types/views";
+
+export const useViewsStore = create<any>()(
+  devtools(
+    persist(
+      (set) => ({
+        view: null,
+        filters: null,
+        setView: (s: TView) => set({ view: s }),
+      }),
+      {
+        name: "viewsStore",
+      },
+    ),
+  ),
+);

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -32,7 +32,7 @@ def index():
     )
 
 
-@app.route("/app/webpage/<path:path>")
+@app.route("/app/<path:path>")
 @login_required
 def webpage(path):
     return render_template(


### PR DESCRIPTION
## Done

 - Implemented Tabular view for projects & pages
 - Added following views:
    - Table view
    - Owned by me
    - Reviewed by me
 - Updated Tree View 
 - Redesigned sidebar
 - Implemented filters logic:
   - filter by owners
   - filter by reviewers
   - filter by products
   - query based filtering
 - Preserve filters history
 - Preserve opened project and scroll history
 - Added highlight effect on selected row upon back navigation

## QA

### QA steps

 - Clone this branch locally
 - Run the project using:
   - `docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres`
   - `docker run -d -p 6379:6379 redis`
- Verify the newly implemented features match the [figma](https://www.figma.com/design/uVXFi46C7ZgriDoWEnsv1U/24.10-Content-system--CMS-?node-id=669-8414&p=f&m=dev) and work as expected.
- Verify the views work as expected and only show relevant data. For example, the view "Owned by me" should only show the views where you are the owner.
- Go to "Table View", click on any project. Select a page. You should see a "Back" button on the top of the page. Click on it. Verify it goes back to the table view. Also verify that the project is still expanded/opened and the previously selected page is scroll into view as well as highlighted.
- Assign multiple reviewers and products to any page. Then in the table view, the reviewer and product columns should initially show 2-3 entries and should show a toggle button to show/hide more along with the remainder count.

## Fixes

 - Fixes [WD-21475](https://warthogs.atlassian.net/browse/WD-21475)
 - Fixes [WD-21495](https://warthogs.atlassian.net/browse/WD-21495)
 - Fixes [WD-18275](https://warthogs.atlassian.net/browse/WD-18275)
 - Fixes [WD-18277](https://warthogs.atlassian.net/browse/WD-18277)

[WD-21475]: https://warthogs.atlassian.net/browse/WD-21475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ