### PR TITLE
[WD-21921] chore: clean up HMR config

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,8 @@ $ docker inspect <postgres-container-id> | grep IPAddress
 
 To ensure hot module reloading, make sure to do the following changes.
 
-- Add <code>FLASK_ENV=development</code> in .env.local file.
-- Comment out <code>"process.env.NODE_ENV": '"production"'</code> in vite.config.ts file.
-- Run the vite dev server locally, using <code>yarn run dev</code>.
+- Set <code>FLASK_ENV=development</code> in .env.local file.
+- Run the vite dev server locally, using <code>yarn dev</code>.
 
 ### Background tasks
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,8 +18,9 @@ export default defineConfig({
     sourcemap: true,
   },
   define: {
-    "process.env.NODE_ENV": '"production"',
-    "process.env": {},
+    "process.env": {
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV || "development"),
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Done

 - Updated Readme
 - Cleaned up vite.config.ts

## QA

### QA steps

 - Check out this branch
 - Run the project in dev mode and see that it works
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgre
source .venv/bin/activate
set -a
source .env
source .env.local
set +a
flask --app webapp.app run --debug
```

In a separate terminal, run 
```bash
yarn dev
```

## Fixes

 - Fixes [WD-21921](https://warthogs.atlassian.net/browse/WD-21921)


[WD-21921]: https://warthogs.atlassian.net/browse/WD-21921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ