### PR TITLE
[WD-22036] feat: attach Jira task with webpage, provided copydoc link

### DIFF
--- a/webapp/routes/jira.py
+++ b/webapp/routes/jira.py
@@ -352,7 +352,8 @@ def attach_jira_with_webpage(body: AttachJiraWithWebpageReq):
     This function creates a new entry in jira_tasks table with the provided
     copy_doc_link, jira_id and associated webpage.
     Args:
-        body (dict): The request body containing the copy_doc_link and jira_id.
+        body (dict): The request body containing the copy_doc_link, jira_id
+        and summary.
     Returns:
         Response: A JSON response indicating the result of the operation.
         - If successful, returns a 200 status with a success message.
@@ -361,6 +362,7 @@ def attach_jira_with_webpage(body: AttachJiraWithWebpageReq):
     try:
         copy_doc_link = body.copy_doc_link
         jira_id = body.jira_id
+        summary = body.summary
 
         # extract google doc id
         match = re.search(r"/d/([a-zA-Z0-9_-]+)", copy_doc_link)
@@ -389,6 +391,7 @@ def attach_jira_with_webpage(body: AttachJiraWithWebpageReq):
             jira_id=jira_id,
             webpage_id=webpage.id,
             user_id=webpage.owner_id,
+            summary=summary,
         )
 
         # clean the cache for a new Jira task to appear in the tree

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -73,3 +73,8 @@ class SetProductsModel(BaseModel):
 
 class PlaywrightCleanupReqBody(BaseModel):
     jira_tasks: List[str]
+
+
+class AttachJiraWithWebpageReq(BaseModel):
+    copy_doc_link: str
+    jira_id: str

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -78,3 +78,4 @@ class PlaywrightCleanupReqBody(BaseModel):
 class AttachJiraWithWebpageReq(BaseModel):
     copy_doc_link: str
     jira_id: str
+    summary: str


### PR DESCRIPTION
## Done

 - Added a new endpoint `/api/attach-jira-with-webpage` to be called by people from content team.

## QA

### QA steps

 - Check out this branch
 - Run the project using 

```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis
dotrun build && dotrun
```

- Call the following endpoint with the payload
`POST localhost:8104/api/attach-jira-with-webpage`
```json
{
    "jira_id":  "WD-1234",
    "copy_doc_link": "https://docs.google.com/document/d/19TIwT-GU5wADQmohicj14MnpHEqNqp0422WLunFsbJU"
}
```

- Verify the following success response
```json
{
    "message": "Jira task attached successfully"
}
```

- Additionally, you can ssh into your postgres container, and verify the presence of new record in `jira_tasks` table.

## Fixes

 - Fixes [WD-22036](https://warthogs.atlassian.net/browse/WD-22036)


[WD-22036]: https://warthogs.atlassian.net/browse/WD-22036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ