### PR TITLE
[WD-22062] Make non-webpage nodes unclickable and exclude partials

### DIFF
--- a/migrations/versions/2e86822886aa_add_ext_to_webpages.py
+++ b/migrations/versions/2e86822886aa_add_ext_to_webpages.py
@@ -1,0 +1,26 @@
+"""Add ext to webpages
+
+Revision ID: 2e86822886aa
+Revises: ac63c9eebbec
+Create Date: 2025-06-03 11:38:42.644973
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2e86822886aa'
+down_revision = 'ac63c9eebbec'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "webpages", sa.Column("ext", sa.String(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("webpages", "ext")

--- a/static/client/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/static/client/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 
+import { Button, Tooltip } from "@canonical/react-components";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { type IBreadcrumb } from "./Breadcrumbs.types";
@@ -59,12 +60,20 @@ const Breadcrumbs = () => {
                 {bc.name}
               </a>
             ) : (
-              <span className="p-text--small-caps">{bc.name}</span>
+              <Tooltip
+                message="This part of the path isn't a page and can't be opened"
+                position="btm-center"
+                zIndex={999}
+              >
+                <Button className="p-button--base u-no-margin u-no-padding" disabled>
+                  {bc.name}
+                </Button>
+              </Tooltip>
             )
           ) : (
             <span className="p-text--small-caps">{bc.name}</span>
           )}
-          {index < breadcrumbs.length - 1 && <span>&nbsp;/&nbsp;</span>}
+          {index < breadcrumbs.length - 1 && <span aria-hidden="true">&nbsp;/&nbsp;</span>}
         </React.Fragment>
       ))}
     </div>

--- a/static/client/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/static/client/components/Breadcrumbs/Breadcrumbs.tsx
@@ -65,7 +65,7 @@ const Breadcrumbs = () => {
                 position="btm-center"
                 zIndex={999}
               >
-                <Button className="p-button--base u-no-margin u-no-padding" disabled>
+                <Button className="p-button--base p-text--small-caps u-no-margin u-no-padding" disabled>
                   {bc.name}
                 </Button>
               </Tooltip>

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -24,7 +24,11 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
         setExpanded((prevValue) => !prevValue);
         setChildrenHidden((prevValue) => !prevValue);
       } else {
-        onSelect(page.name);
+        if (page.ext !== ".dir") onSelect(page.name);
+        else {
+          setExpanded((prevValue) => !prevValue);
+          setChildrenHidden((prevValue) => !prevValue);
+        }
       }
     },
     [expandButtonRef, page, onSelect],

--- a/static/client/components/Views/TableView/TableViewRowItem.tsx
+++ b/static/client/components/Views/TableView/TableViewRowItem.tsx
@@ -11,7 +11,7 @@ interface TableViewRowItemProps {
 const TableViewRowItem: React.FC<TableViewRowItemProps> = ({ page }) => {
   return (
     <>
-      <TableViewRow page={page} />
+      {page.ext !== ".dir" && <TableViewRow page={page} />}
       {page?.children?.map((child) => {
         return <TableViewRowItem key={`${child.project?.name}${child.url}`} page={child} />;
       })}

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -36,6 +36,7 @@ export interface IPage {
     name: string;
     updated_at: string;
   };
+  ext?: string;
 }
 
 export interface IPagesResponse {

--- a/static/client/services/tree/pages.ts
+++ b/static/client/services/tree/pages.ts
@@ -1,16 +1,23 @@
 import type { IPage } from "@/services/api/types/pages";
 
 // recursively find the page in the tree by the given name (URL)
-export function findPage(tree: IPage, pageName: string, prefix: string = ""): boolean {
+export function findPage(
+  tree: IPage,
+  pageName: string,
+  prefix: string = "",
+  returnObject: boolean = false,
+): boolean | IPage {
   const parts = pageName.split("/");
+
   for (let i = 0; i < tree.children.length; i += 1) {
     if (tree.children[i].name === `${prefix}/${parts[1]}`) {
       if (parts.length > 2) {
-        return findPage(tree.children[i], `/${parts.slice(2).join("/")}`, `${prefix}/${parts[1]}`);
+        return findPage(tree.children[i], `/${parts.slice(2).join("/")}`, `${prefix}/${parts[1]}`, returnObject);
       }
-      return true;
+      return returnObject ? tree.children[i] : true;
     }
   }
+
   return false;
 }
 

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -101,6 +101,7 @@ class Webpage(db.Model, DateTimeMixin):
     parent_id: int = Column(Integer, ForeignKey("webpages.id"))
     owner_id: int = Column(Integer, ForeignKey("users.id"))
     status: str = Column(Enum(WebpageStatus), default=WebpageStatus.AVAILABLE)
+    ext: str = Column(String, nullable=True)
 
     project = relationship("Project", back_populates="webpages")
     owner = relationship("User", back_populates="webpages")

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -238,7 +238,6 @@ def get_extended_path(path):
     """Get the path extended by the file"""
     with path.open("r") as f:
         for line in f.readlines():
-            # TODO: also match single quotes \'
             if ".html" in str(path):
                 if match := re.search("{% extends [\"'](.*?)[\"'] %}", line):
                     return match.group(1)

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -259,6 +259,7 @@ def create_node():
         "description": None,
         "link": None,
         "children": [],
+        "ext": None,
     }
 
 
@@ -296,6 +297,9 @@ def scan_directory(path_name, base=None):
             # Get tags, add as child
             tags = get_tags_rolling_buffer(index_path)
             node = update_tags(node, tags)
+    
+    else:
+        node["ext"] = ".dir"
 
     # Cycle through other files in this directory
     for child in node_path.iterdir():
@@ -306,6 +310,7 @@ def scan_directory(path_name, base=None):
                 child, extended_path, is_index=False
             ):
                 child_tags = get_tags_rolling_buffer(child)
+                child_tags["ext"] = child.suffix
                 # If the child has no copydocs link, use the parent's link
                 if not child_tags.get("link") and extended_path:
                     child_tags["link"] = get_extended_copydoc(

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -16,7 +16,7 @@ TAG_MAPPING = {
     "link": ["meta_copydoc"],
 }
 
-EXCLUDE_PATHS = ["tutorials", "engage", "blog", "partials"]
+EXCLUDE_PATHS = ["partials"]
 
 def is_index(path):
     return path.name == "index.html"

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -18,6 +18,7 @@ TAG_MAPPING = {
 
 EXCLUDE_PATHS = ["partials"]
 
+
 def is_index(path):
     return path.name == "index.html"
 
@@ -39,9 +40,11 @@ def is_template(path):
             return True
     return False
 
+
 def is_partial(path):
     """
-    Return True if the file name starts with an underscore, that indicates it as a partial
+    Return True if the file name starts with an underscore, 
+    that indicates it as a partial
 
     Partials are templates that are not meant to be rendered directly, but
     included in other templates.
@@ -216,7 +219,7 @@ def is_valid_page(path, extended_path, is_index=True):
     """
 
     path = Path(path)
-    
+
     if not path.is_file() or is_template(path) or is_partial(path):
         return False
 
@@ -297,7 +300,7 @@ def scan_directory(path_name, base=None):
             # Get tags, add as child
             tags = get_tags_rolling_buffer(index_path)
             node = update_tags(node, tags)
-    
+
     else:
         node["ext"] = ".dir"
 

--- a/webapp/site_repository.py
+++ b/webapp/site_repository.py
@@ -254,7 +254,8 @@ class SiteRepository:
             .all()
         )
         # build tree from repository in case DB table is empty
-        # TODO: Revert this line to `if not webpages ...` before merging this PR
+        # TODO: Revert this line to `if not webpages ...` 
+        # before merging this PR
         # This is only for QA
         if True or not webpages or self._has_incomplete_pages(webpages):
             tree = self.get_new_tree()

--- a/webapp/site_repository.py
+++ b/webapp/site_repository.py
@@ -254,7 +254,9 @@ class SiteRepository:
             .all()
         )
         # build tree from repository in case DB table is empty
-        if not webpages or self._has_incomplete_pages(webpages):
+        # TODO: Revert this line to `if not webpages ...` before merging this PR
+        # This is only for QA
+        if True or not webpages or self._has_incomplete_pages(webpages):
             tree = self.get_new_tree()
         # otherwise, build tree from DB
         else:

--- a/webapp/site_repository.py
+++ b/webapp/site_repository.py
@@ -305,6 +305,7 @@ class SiteRepository:
         webpage.description = node["description"]
         webpage.copy_doc_link = node["link"]
         webpage.parent_id = parent_id
+        webpage.ext = node["ext"]
         if webpage.status == WebpageStatus.NEW:
             webpage.status = WebpageStatus.AVAILABLE
 


### PR DESCRIPTION
**Note**: Revert this temporary QA change before merging
```python
# TODO: Revert this line to `if not webpages ...` before merging this PR
# This is only for QA
if True or not webpages or self._has_incomplete_pages(webpages):
``` 

## Done

 - Exclude partials and manually provided excluded directories from tree generation
 - Store node extension e.g., .html, .md, .dir
 - Disable non-webpage nodes in sidebar tree so they are not clickable
 - Disable breadcrumbs for non-webpage url paths so they are not clickable
 - Hide non-webpage nodes from table view
 - [drive by]: modify the `findPage` helper to conditionally return bool or webpage object
 - Added tooltip on disabled parts of the breadcrumb

## QA

### QA steps

 - Clone this repo and check out this PR
 - Run the project using

```bash
rm -rf .venv
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgre
docker run -d -p 6379:6379
python -m venv .venv
source .venv/bin/activate
python -m pip install -r requirements.txt
set -a
source .env
source .env.local
set +a
flask --app webapp.app run --debug
```

In a separate terminal, run

```bash
yarn dev
```

In a separate terminal, start the celery worker

```bash
source .venv/bin/activate
set -a
source .env
source .env.local
set +a

celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

- The application should be accessible at localhost:5000 and should show loading when cloning repositories
- In the left sidebar, select TREE VIEW and choose canonical.com
- Find "legal" and click on it
- It should only show the nested children and not open up a detailed page
- Click on the nested children, if they are actual webpages they will be accessible, else if they are only intermediary directories without actual webpage, they will not be clickable.
- Click legal > contributors > faq, the detailed page should open up for faq page. Verify the breadcrumbs are disabled for non-webpage paths.
- Parent pages (folders) that are not webpages should not be clickable. Pages that are nodes (not parent pages) that are not webpages (like partials) should not be returned by “get-tree” endpoint.

## Fixes

 - Fixes [WD-22062](https://warthogs.atlassian.net/browse/WD-22062)

## Screenshots

![simplescreenrecorder-2025-06-04_10 10 23-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ef274fb9-267e-4733-a8eb-6eecdaf07f7a)


[WD-22062]: https://warthogs.atlassian.net/browse/WD-22062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ