### PR TITLE
[WD-22501] feat: include and parse markdown files in project trees on content system

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "start": "yarn run build && concurrently --raw 'yarn run watch' 'yarn run serve'",
     "test": "vitest",
     "watch": "watch -p 'static/client/**/*.{js,jsx,ts,tsx,scss}' -c 'yarn run build'",
-    "dev": "vite"
+    "dev": "vite",
+    "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
+    "format-python": "black --line-length 79 webapp tests"
   },
   "dependencies": {
     "@canonical/react-components": "0.60.0",

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -22,13 +22,17 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
     window.open(page.copy_doc_link);
   }, [page]);
 
+  const pageExtension = useMemo(() => {
+    return page.ext || ".html";
+  }, [page.ext]);
+
   const openGitHub = useCallback(() => {
     if (page.children.length) {
-      window.open(`${config.ghLink(project)}${page.name}/index.html`);
+      window.open(`${config.ghLink(project)}${page.name}/index${pageExtension}`);
     } else {
-      window.open(`${config.ghLink(project)}${page.name}.html`);
+      window.open(`${config.ghLink(project)}${page.name}${pageExtension}`);
     }
-  }, [page, project]);
+  }, [page.children.length, page.name, pageExtension, project]);
 
   const createNewPage = useCallback(() => {
     setChangeType(ChangeRequestType.NEW_WEBPAGE);

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -52,7 +52,7 @@ def is_template(path):
 
 def is_partial(path):
     """
-    Return True if the file name starts with an underscore, 
+    Return True if the file name starts with an underscore,
     that indicates it as a partial
 
     Partials are templates that are not meant to be rendered directly, but
@@ -90,7 +90,7 @@ def extends_base(path, base="templates"):
                     else:
                         # extract absolute path from the parent path
                         absolute_path = str(path)[
-                            0 : str(path).find(base) + len(base)
+                            0: str(path).find(base) + len(base)
                         ]
                         # check if the file from which the current file
                         # extends extends from the base template
@@ -148,7 +148,7 @@ def get_extended_copydoc(path, base):
     with base.joinpath(path).open("r") as f:
         file_data = f.read()
         if match := re.search(
-            "\{\% block meta_copydoc *\%\}(.*)\{\%( *)endblock", file_data
+            r"\{\% block meta_copydoc *\%\}(.*)\{\%( *)endblock", file_data
         ):
             return match.group(1)
 
@@ -166,8 +166,6 @@ def get_tags_rolling_buffer(path):
 
     # check if the path is html or md file
     is_md = path.suffix == ".md"
-
-    print("is_md = ", is_md)
 
     with path.open("r") as f:
         for tag in available_tags:
@@ -189,7 +187,9 @@ def get_tags_rolling_buffer(path):
                             buffer.append(line)
 
                         if not is_buffering and (
-                            match := re.search(f"{{% block {variant}( *)%}}", line)
+                            match := re.search(
+                                f"{{% block {variant}( *)%}}", line
+                            )
                         ):
                             # We remove line contents before the tag
                             line = line[match.start() :]  # noqa: E203
@@ -198,12 +198,14 @@ def get_tags_rolling_buffer(path):
                             is_buffering = True
                             variants_mapping[tag] = variant
 
-                        # We search for the end of the tag in the existing buffer
+                        # We search for the end of the tag in the existing
+                        # buffer
                         buffer_string = "".join(buffer)
                         if is_buffering and re.search(
                             "(.*){%( *)endblock", buffer_string
                         ):
-                            # We save the buffer contents to the tags dictionary
+                            # We save the buffer contents to the tags
+                            # dictionary
                             tags[tag] = buffer_string
 
                             # We extract the text within the tags
@@ -216,12 +218,15 @@ def get_tags_rolling_buffer(path):
                             is_buffering = False
                             tag_found = True
                             break
-                
+
                 else:
                     for line in f:
-                        match = re.match(rf"^\s*{variant}\s*:\s*\"?(.+?)\"?\s*$", line, re.IGNORECASE)
+                        match = re.match(
+                            rf"^\s*{variant}\s*:\s*\"?(.+?)\"?\s*$",
+                            line,
+                            re.IGNORECASE,
+                        )
                         if match:
-                            print(f"Found tag '{variant}' in {path}")
                             variants_mapping[tag] = variant
                             tags[tag] = match.group(1).strip()
                             tag_found = True


### PR DESCRIPTION
## Problem Statement
Currently, the content system only supports and lists .html files. Some of our pages on various sites are markdown files. We need to be able to show those markdown pages as well, for content team.

## Done

 - Added .md files in sites tree
 - Parse .md files to extract metadata e.g., title, description and copydoc link.

## QA

### QA steps

 - Check out this repo
 - Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis

dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

In another terminal, run 
```bash
yarn dev
```

- Access the application on localhost:8104/app
- Wait for the projects to load
- Select Table View > ubuntu.com
- Verify the following pages are listed, and are accessible

1. /appliance
2. /appliance/adguard
3. /appliance/openhab
4. /appliance/lxd

- Verify the title, description and copydoc links (if exists)

## Fixes

 - Fixes [WD-22501](https://warthogs.atlassian.net/browse/WD-22501)

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.


[WD-22501]: https://warthogs.atlassian.net/browse/WD-22501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ