### PR TITLE
[WD-23309] feat: optimize page creation flow for better performance

### DIFF
--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -10,6 +10,7 @@ import NavigationItems from "./NavigationItems";
 import NavigationCollapseToggle from "@/components/Navigation/NavigationCollapseToggle";
 import SiteSelector from "@/components/SiteSelector";
 import { VIEW_OWNED, VIEW_REVIEWED, VIEW_TABLE, VIEW_TREE } from "@/config";
+import { useProjects } from "@/services/api/hooks/projects";
 import type { IUser } from "@/services/api/types/users";
 import type { TView } from "@/services/api/types/views";
 import { useStore } from "@/store";
@@ -25,6 +26,7 @@ const Navigation = (): JSX.Element => {
     state.setView,
     state.setExpandedProject,
   ]);
+  const { data: projects, isLoading } = useProjects();
 
   const logout = useCallback(() => {
     setUser({} as IUser);
@@ -108,7 +110,7 @@ const Navigation = (): JSX.Element => {
               {isViewActive(VIEW_TREE) && (
                 <>
                   <SiteSelector />
-                  <NavigationItems />
+                  {!(isLoading || !projects.length) && <NavigationItems />}
                 </>
               )}
             </div>

--- a/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
+++ b/static/client/components/Navigation/NavigationElement/NavigationElement.tsx
@@ -46,7 +46,7 @@ const NavigationElement = ({ activePageName, page, project, onSelect }: INavigat
   }, [page, project, location]);
 
   useEffect(() => {
-    if (page?.children.length) {
+    if (page?.children?.length) {
       setChildren(
         page.children.sort((c1, c2) =>
           NavigationServices.formatPageName(c1.name) < NavigationServices.formatPageName(c2.name) ? -1 : 1,

--- a/static/client/components/RequestTaskModal/RequestTaskModal.tsx
+++ b/static/client/components/RequestTaskModal/RequestTaskModal.tsx
@@ -2,7 +2,6 @@ import { type ChangeEvent, useCallback, useMemo, useState } from "react";
 import React from "react";
 
 import { Button, Input, Modal, RadioInput, Spinner, Textarea, Tooltip, useNotify } from "@canonical/react-components";
-import type { QueryObserverResult } from "react-query";
 import { useNavigate } from "react-router-dom";
 
 import type { IRequestTaskModalProps } from "./RequestTaskModal.types";
@@ -11,9 +10,7 @@ import Reporter from "@/components/Reporter";
 import config from "@/config";
 import { usePages } from "@/services/api/hooks/pages";
 import { PagesServices } from "@/services/api/services/pages";
-import type { IPagesResponse } from "@/services/api/types/pages";
 import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";
-import type { IApiBasicError } from "@/services/api/types/query";
 import { DatesServices } from "@/services/dates";
 import { useStore } from "@/store";
 
@@ -69,11 +66,11 @@ const RequestTaskModal = ({
       onClose();
       if (refetch) {
         refetch()
-          .then((data: QueryObserverResult<IPagesResponse, IApiBasicError>[]) => {
+          .then((data) => {
             if (data?.length) {
-              const project = data.find((p) => p.data?.data?.name === selectedProject?.name);
-              if (project && project.data?.data) {
-                setSelectedProject(project.data.data);
+              const project = data.find((p) => p.data?.name === selectedProject?.name);
+              if (project && project.data) {
+                setSelectedProject(project.data);
               }
             }
           })

--- a/static/client/components/Search/Search.services.ts
+++ b/static/client/components/Search/Search.services.ts
@@ -17,12 +17,12 @@ const checkMatches = (pages: IPage[], value: string, matches: IMatch[], project:
   });
 };
 
-export const searchForMatches = (value: string, tree: IPagesResponse[]): IMatch[] => {
+export const searchForMatches = (value: string, tree: IPagesResponse["data"][]): IMatch[] => {
   const matches: IMatch[] = [];
 
   tree.forEach((project) => {
-    if (project.data.templates.children?.length) {
-      checkMatches(project.data.templates.children, value, matches, project.data.name);
+    if (project.templates.children?.length) {
+      checkMatches(project.templates.children, value, matches, project.name);
     }
   });
 
@@ -30,10 +30,10 @@ export const searchForMatches = (value: string, tree: IPagesResponse[]): IMatch[
 };
 
 export const getProjectByName = (
-  data: IPagesResponse[] | undefined,
+  data: IPagesResponse["data"][] | undefined,
   projectName: string,
 ): IPagesResponse["data"] | undefined => {
-  return data?.find((project) => project.data.name === projectName)?.data;
+  return data?.find((project) => project.name === projectName);
 };
 
 export * as SearchServices from "./Search.services";

--- a/static/client/components/Search/Search.tsx
+++ b/static/client/components/Search/Search.tsx
@@ -20,7 +20,7 @@ const Search = (): JSX.Element => {
 
   const handleChange = useCallback(
     (inputValue: string) => {
-      if (inputValue.length > 2 && data?.length && data[0]?.data) {
+      if (inputValue.length > 2 && data?.length && data[0]) {
         setMatches(SearchServices.searchForMatches(inputValue, data));
       } else if (inputValue.length === 0) {
         setMatches([]);
@@ -63,7 +63,7 @@ const Search = (): JSX.Element => {
       <SearchBox
         autocomplete="off"
         className="l-search-box"
-        disabled={!(data?.length && data[0]?.data)}
+        disabled={!(data?.length && data[0])}
         onBlur={handleInputBlur}
         onChange={handleChange}
         placeholder="Search a webpage"

--- a/static/client/components/Views/TableView/ProjectTitle.tsx
+++ b/static/client/components/Views/TableView/ProjectTitle.tsx
@@ -9,7 +9,8 @@ interface ProjectTitleProps {
 
 function countPages(page: IPage): number {
   if (!page) return 0;
-  return 1 + page.children?.reduce((acc, child) => acc + countPages(child), 0);
+  const children = page.children ?? [];
+  return 1 + children?.reduce((acc, child) => acc + countPages(child), 0);
 }
 
 const ProjectTitle: React.FC<ProjectTitleProps> = ({ project }) => {

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import MainLayout from "@/components/MainLayout";
+import NewWebpage from "@/pages/NewWebpage";
 import Owned from "@/pages/views/Owned";
 import Reviewed from "@/pages/views/Reviewed";
 import { useAuth } from "@/services/api/hooks/auth";
@@ -27,6 +28,7 @@ const Main = (): React.ReactNode => {
         <Route element={<MainLayout />} path="/app">
           <Route element={<Owned />} path="views/owned" />
           <Route element={<Reviewed />} path="views/reviewed" />
+          <Route element={<NewWebpage />} path="new-webpage" />
           {getDynamicRoutes()}
         </Route>
         <Route element={<Navigate to="/app" />} path="/" />

--- a/static/client/pages/Main/Main.tsx
+++ b/static/client/pages/Main/Main.tsx
@@ -17,8 +17,7 @@ const Main = (): React.ReactNode => {
   function getDynamicRoutes() {
     if (!data?.length) return;
     return data.map(
-      (project) =>
-        project?.data?.templates && RoutesServices.generateRoutes(project.data.name, [project.data.templates]),
+      (project) => project?.templates && RoutesServices.generateRoutes(project.name, [project.templates]),
     );
   }
 

--- a/static/client/pages/NewWebpage/NewWebpage.tsx
+++ b/static/client/pages/NewWebpage/NewWebpage.tsx
@@ -31,7 +31,7 @@ const NewWebpage = (): JSX.Element => {
   const [reviewers, setReviewers] = useState<IUser[]>([]);
   const [products, setProducts] = useState<number[]>([]);
   const [location, setLocation] = useState<string>();
-  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [buttonDisabled, setButtonDisabled] = useState(true);
   const [reloading, setReloading] = useState<(typeof LoadingState)[keyof typeof LoadingState]>(LoadingState.INITIAL);
 
   const [selectedProject, setSelectedProject] = useStore((state) => [state.selectedProject, state.setSelectedProject]);

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -27,12 +27,12 @@ const Webpage = ({ page, project }: IWebpageProps): JSX.Element => {
   }, [page.ext]);
 
   const openGitHub = useCallback(() => {
-    if (page.children.length) {
+    if (page.children?.length) {
       window.open(`${config.ghLink(project)}${page.name}/index${pageExtension}`);
     } else {
       window.open(`${config.ghLink(project)}${page.name}${pageExtension}`);
     }
-  }, [page.children.length, page.name, pageExtension, project]);
+  }, [page.children?.length, page.name, pageExtension, project]);
 
   const createNewPage = useCallback(() => {
     setChangeType(ChangeRequestType.NEW_WEBPAGE);

--- a/static/client/services/api/hooks/pages.ts
+++ b/static/client/services/api/hooks/pages.ts
@@ -7,12 +7,12 @@ import { PagesServices } from "@/services/api/services/pages";
 import type { IPagesResponse } from "@/services/api/types/pages";
 import type { IApiBasicError, IUseQueryHookRest } from "@/services/api/types/query";
 
-export function usePages(noCache: boolean = false): IUseQueryHookRest<IPagesResponse[]> {
-  const results = useQueries<UseQueryOptions<IPagesResponse, IApiBasicError>[]>(
+export function usePages(noCache: boolean = false): IUseQueryHookRest<IPagesResponse["data"][]> {
+  const results = useQueries<UseQueryOptions<IPagesResponse["data"], IApiBasicError>[]>(
     config.projects.map((project) => {
       return {
         queryKey: ["pages", project],
-        queryFn: () => PagesServices.getPages(project, noCache),
+        queryFn: () => PagesServices.getPages(project, noCache).then((response) => response.data),
         staleTime: noCache ? 0 : 300000,
         cacheTime: noCache ? 0 : 300000,
         refetchOnMount: false,

--- a/static/client/services/api/hooks/projects.ts
+++ b/static/client/services/api/hooks/projects.ts
@@ -12,9 +12,8 @@ export function useProjects() {
 
   const [projects, setProjects] = useState<IPagesResponse["data"][]>([]);
 
-  const hasData = data?.every((project) => project?.data);
-  if (!isLoading && data?.length && hasData && projects.length !== data.length) {
-    setProjects(data.map((project) => project.data));
+  if (!isLoading && data?.length && projects.length !== data.length) {
+    setProjects(data);
   }
 
   function filterProjectsAndPages(data: IPagesResponse["data"]) {
@@ -81,7 +80,7 @@ export function useProjects() {
 
   return {
     data: getFilteredProjects(),
-    unfilteredProjects: data?.map((project) => project?.data),
+    unfilteredProjects: data,
     isLoading,
     isFilterApplied,
   };

--- a/static/client/services/api/hooks/projects.ts
+++ b/static/client/services/api/hooks/projects.ts
@@ -12,7 +12,8 @@ export function useProjects() {
 
   const [projects, setProjects] = useState<IPagesResponse["data"][]>([]);
 
-  if (!isLoading && data?.length && projects.length !== data.length) {
+  const hasData = data?.every((project) => project!);
+  if (!isLoading && data?.length && hasData && projects.length !== data.length) {
     setProjects(data);
   }
 

--- a/static/client/services/api/types/pages.ts
+++ b/static/client/services/api/types/pages.ts
@@ -56,7 +56,9 @@ export interface INewPage {
 }
 
 export interface INewPageResponse {
-  copy_doc: string;
+  data: {
+    webpage: IPage;
+  };
 }
 
 export const ChangeRequestType = {

--- a/static/client/services/api/types/query.ts
+++ b/static/client/services/api/types/query.ts
@@ -12,7 +12,7 @@ export interface IApiBasicError {
 interface IUseQueryHookBase<T extends unknown> {
   isLoading?: boolean;
   data: T | undefined;
-  refetch?: () => Promise<QueryObserverResult<IPagesResponse, IApiBasicError>[]>;
+  refetch?: () => Promise<QueryObserverResult<IPagesResponse["data"], IApiBasicError>[]>;
   isFetching?: boolean;
 }
 

--- a/static/client/services/routes/index.tsx
+++ b/static/client/services/routes/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { Route } from "react-router-dom";
 
-import NewWebpage from "@/pages/NewWebpage";
 import Webpage from "@/pages/Webpage";
 import { type IPage } from "@/services/api/types/pages";
 
@@ -14,7 +13,6 @@ export function generateRoutes(project: string, pages: IPage[]): JSX.Element[] {
         key={page.name}
         path={`webpage/${project}${page.name}`}
       />
-      <Route element={<NewWebpage />} key="new-webpage" path="new-webpage" />
       {page.children?.length && generateRoutes(project, page.children)}
     </React.Fragment>
   ));

--- a/static/client/services/tree/pages.ts
+++ b/static/client/services/tree/pages.ts
@@ -1,4 +1,6 @@
-import type { IPage } from "@/services/api/types/pages";
+import type { QueryClient } from "react-query";
+
+import type { IPage, IPagesResponse } from "@/services/api/types/pages";
 
 // recursively find the page in the tree by the given name (URL)
 export function findPage(
@@ -19,6 +21,58 @@ export function findPage(
   }
 
   return false;
+}
+
+export function findPageById(pageId: number, tree: IPage): IPage | boolean {
+  if (tree.id === pageId) return tree;
+  for (let i = 0; i < tree.children.length; i += 1) {
+    if (pageId === tree.children[i].id) return tree.children[i];
+    if (tree.children[i].children?.length) {
+      const found = findPageById(pageId, tree.children[i]);
+      if (found) return found;
+    }
+  }
+  return false;
+}
+
+export function insertPage(page: IPage, queryClient: QueryClient) {
+  if (!page || !page.project?.name || !page.id || !page.parent_id) return;
+
+  const projectName = page.project.name;
+
+  // Access the specific cache entry
+  const key = ["pages", projectName];
+  const oldCache = queryClient.getQueryData<IPagesResponse["data"]>(key); // Replace 'any' with your exact type
+
+  if (!oldCache) return;
+
+  // Check if the page already exists
+  const pageExists = findPageById(page.id, oldCache.templates);
+  if (pageExists) return;
+
+  // find the parent page to insert the new page under
+
+  const parentPage = findPageById(page.parent_id, oldCache.templates) as IPage;
+
+  if (!parentPage) return;
+  if (!parentPage.hasOwnProperty("children")) parentPage.children = [];
+
+  // add the new page to the parent's children
+  parentPage.children.push(page);
+
+  // Immutable update: insert page
+  const updatedTemplates = {
+    ...oldCache.templates,
+    children: [...oldCache.templates.children],
+  };
+
+  const updatedData = {
+    ...oldCache,
+    templates: updatedTemplates,
+  };
+
+  // Update the React Query cache
+  queryClient.setQueryData(key, updatedData);
 }
 
 export * as TreeServices from "./pages";

--- a/webapp/routes/jira.py
+++ b/webapp/routes/jira.py
@@ -303,7 +303,18 @@ def create_page(body: CreatePageModel):
         )
 
     invalidate_cache(new_webpage[0])
-    return jsonify({"webpage": convert_webpage_to_dict(new_webpage[0], new_webpage[0].owner, new_webpage[0].project)}), 201
+    return (
+        jsonify(
+            {
+                "webpage": convert_webpage_to_dict(
+                    new_webpage[0],
+                    new_webpage[0].owner,
+                    new_webpage[0].project,
+                )
+            }
+        ),
+        201,
+    )
 
 
 def invalidate_cache(webpage: Webpage):

--- a/webapp/routes/jira.py
+++ b/webapp/routes/jira.py
@@ -4,6 +4,7 @@ from flask_pydantic import validate
 
 from webapp.enums import JiraStatusTransitionCodes
 from webapp.helper import (
+    convert_webpage_to_dict,
     create_copy_doc,
     create_jira_task,
     get_or_create_user_id,
@@ -301,7 +302,8 @@ def create_page(body: CreatePageModel):
             product_id=product_id,
         )
 
-    return jsonify({"copy_doc": copy_doc}), 201
+    invalidate_cache(new_webpage[0])
+    return jsonify({"webpage": convert_webpage_to_dict(new_webpage[0], new_webpage[0].owner, new_webpage[0].project)}), 201
 
 
 def invalidate_cache(webpage: Webpage):


### PR DESCRIPTION
## Problem Statement

When a user clicks on `Request New Page` button, fills out details and submits the form, the request takes a lot of time because it has to:
       1. Create a google copydoc
       2. Re-fetch the entire tree (all the projects) to invalidate cache
       3. Refresh the page

This wait time can be reduced by:
     1. Eliminating the need to re-fetch the entire tree (by optimizing the flow of data)
     2. Eliminating the need to refresh
     3. Invalidating cache on the backend, after creating a new webpage

## Done

 - Invalidate cache for corresponding repository after creating a new webpage, within create-page request
 - Add a new helper function to insert a webpage w.r.t. to it's parent, within the tree.
 - Update the tree after creating a new webpage, in realtime, without having to re-fetch the tree or reload the page.
 - Drive-by: Cleaned up routes

## QA

### QA steps

 - Check out this repo
 - Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis

dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

In another terminal, run 
```bash
yarn dev
```

- Access the application on localhost:8104/app
- Wait for the projects to load
- Click on "Request new page" button
- Fill out the form and hit submit (Make sure to have VPN on for searching owners and reviewers)
- Make sure the new page is created, opened and reflected in the tree without reloading the page.

## Fixes

 - Fixes [WD-23309](https://warthogs.atlassian.net/browse/WD-23309)
 - Fixes [WD-23310](https://warthogs.atlassian.net/browse/WD-23310)


[WD-23309]: https://warthogs.atlassian.net/browse/WD-23309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ