### PR TITLE
[WD-23891] add more projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ def some_route():
 </details>
 
 <details>
- <summary><code>GET</code> <code><b>/get-tree/site-name/branch-name</b></code> <code>(you can optionally specify the branch)</code></summary>
+ <summary><code>GET</code> <code><b>/get-tree/site-name</b></code></summary>
 </details>
 
 ```json

--- a/data/sites.yaml
+++ b/data/sites.yaml
@@ -3,3 +3,7 @@ sites:
   - canonical.com
   - cn.ubuntu.com
   - jp.ubuntu.com
+  - snapcraft.io
+  - charmhub.io
+  # - canonical.design TODO: uncomment this after repo name changes
+  - netplan.io

--- a/entrypoint
+++ b/entrypoint
@@ -21,7 +21,7 @@ activate() {
     # ===
     flask --app webapp.app db upgrade
 
-    RUN_COMMAND="gunicorn webapp.app:app --name $(hostname) --workers=1 --bind $1"
+    RUN_COMMAND="gunicorn webapp.app:app --name $(hostname) --workers=1 --bind $1 --timeout 60"
 
     if [ "${FLASK_DEBUG:-0}" == "1" ]; then
         RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -8,7 +8,16 @@ export const VIEW_TREE = "tree";
 export const VIEW_TABLE = "table";
 
 const config = {
-  allProjects: ["canonical.com", "ubuntu.com", "cn.ubuntu.com", "jp.ubuntu.com"],
+  allProjects: [
+    "canonical.com",
+    "ubuntu.com",
+    "cn.ubuntu.com",
+    "jp.ubuntu.com",
+    "snapcraft.io",
+    "charmhub.io",
+    // "canonical.design", TODO: uncomment this after repo name changes
+    "netplan.io",
+  ],
   testProjects: ["canonical.com", "jp.ubuntu.com"],
   views: [VIEW_OWNED, VIEW_REVIEWED, VIEW_TREE, VIEW_TABLE] as TView[],
   tooltips: {

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -1,6 +1,5 @@
 export const ENDPOINTS = {
-  getPagesTree: (domain: string, noCache?: boolean, branch: string = "main") =>
-    `/api/get-tree/${domain}/${branch}${noCache ? "/True" : ""}`,
+  getPagesTree: (domain: string, noCache?: boolean) => `/api/get-tree/${domain}/${noCache ? "/True" : ""}`,
   getUsers: (inputStr: string) => `/api/get-users/${inputStr}`,
   setOwner: "/api/set-owner",
   setReviewers: "/api/set-reviewers",

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -55,41 +55,6 @@ DB_LOCK_NAME = "db_lock"
 
 
 @contextmanager
-def site_cloning_lock(site_name: str) -> Generator:
-    """A context manager for acquiring a lock to control access
-    to site cloning operations.
-
-    This function creates a distributed lock using the available Cache to
-    ensure only one process can clone a specific site at a time. If the
-    lock is already acquired by another process, this will poll every 2 seconds
-    until the lock is released.
-
-    Args:
-        site_name: The name of the site to acquire a lock for
-
-    Yields:
-        The current lock status from the cache
-
-    Example:
-        with site_cloning_lock("ubuntu.com"):
-            # Site cloning operations here
-            ...
-
-    """
-    cache = init_cache(current_app)
-    lock_name = f"{site_name}_lock"
-    locked = cache.get(lock_name)
-    while locked:
-        sleep(2)
-        locked = cache.get(lock_name)
-    try:
-        cache.set(lock_name, 1)
-        yield cache.get(lock_name)
-    finally:
-        cache.set(lock_name, 0)
-
-
-@contextmanager
 def database_lock() -> Generator:
     """A context manager for acquiring a lock to control access
     to a shared db.

--- a/webapp/github.py
+++ b/webapp/github.py
@@ -112,16 +112,24 @@ class GitHub:
                     f"Finished cloning {repository} in {retries} retries"
                 )
                 break
-            except Exception as e:
+            except BaseException as e:
                 if retries > MAX_RETRIES:
                     logger.error(
                         f"Failed to clone {repository} after "
                         f"{retries} retries."
                     )
+                    self.cache.set(
+                        f"{BACKGROUND_TASK_RUNNING_PREFIX}-{repository}",
+                        0,
+                    )
                     raise GithubError(
                         f"Failed to clone {repository} after "
                         f"{retries} retries."
                     ) from e
+                logger.error(
+                    f"Error cloning {repository} on try {retries} of "
+                    f"{MAX_RETRIES}: {e}"
+                )
                 retries += 1
         self.cache.set(
             f"{BACKGROUND_TASK_RUNNING_PREFIX}-{repository}",

--- a/webapp/github.py
+++ b/webapp/github.py
@@ -113,7 +113,7 @@ class GitHub:
                 )
                 break
             except BaseException as e:
-                if retries > MAX_RETRIES:
+                if retries >= MAX_RETRIES:
                     logger.error(
                         f"Failed to clone {repository} after "
                         f"{retries} retries."

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -8,6 +8,9 @@ BASE_TEMPLATES = [
     "templates/base_no_nav.html",
     "templates/one-column.html",
     "_base/base.html",
+    "_base-layout.html",
+    "base_layout.html",
+    "base.html",
 ]
 MARKDOWN_TEMPLATES = [
     "legal/_base_legal_markdown.html",

--- a/webapp/routes/tree.py
+++ b/webapp/routes/tree.py
@@ -7,16 +7,16 @@ tree_blueprint = Blueprint("tree", __name__, url_prefix="/api")
 
 
 @tree_blueprint.route(
-    "/get-tree/<string:uri>/<string:branch>",
+    "/get-tree/<string:uri>",
     methods=["GET"],
 )
 @tree_blueprint.route(
-    "/get-tree/<string:uri>/<string:branch>/<string:no_cache>",
+    "/get-tree/<string:uri>/<string:no_cache>",
     methods=["GET"],
 )
 @login_required
-def get_tree(uri: str, branch: str = "main", no_cache: bool = False):
-    site_repository = SiteRepository(uri, current_app, branch=branch)
+def get_tree(uri: str, no_cache: bool = False):
+    site_repository = SiteRepository(uri, current_app)
     # Getting the site tree here ensures that both the cache and db are updated
     tree = site_repository.get_tree_sync(no_cache)
 

--- a/webapp/site_repository.py
+++ b/webapp/site_repository.py
@@ -50,14 +50,12 @@ class SiteRepository:
         self,
         repository_uri: str,
         app: Flask,
-        branch="main",
         db: SQLAlchemy = None,
     ):
         base_dir = app.config["BASE_DIR"]
         self.REPOSITORY_DIRECTORY = f"{base_dir}/repositories"
         self.repository_uri = repository_uri
-        self.cache_key = f"{self.CACHE_KEY_PREFIX}_{repository_uri}_{branch}"
-        self.branch = branch
+        self.cache_key = f"{self.CACHE_KEY_PREFIX}_{repository_uri}"
         self.app = app
         self.logger = app.logger
         self.cache = app.config["CACHE"]
@@ -68,7 +66,7 @@ class SiteRepository:
             self.db = db
 
     def __str__(self) -> str:
-        return f"SiteRepository({self.repository_uri}, {self.branch})"
+        return f"SiteRepository({self.repository_uri})"
 
     def get_repo_path(self, repository_uri: str):
         """Get the repository path"""


### PR DESCRIPTION
## Done

 - Removed "branch" parameter from "get-tree" endpoint, since we always use "main" branch
 - Increased gunicorn's timeout to 1 minute, since default 30 seconds might not be enough to clone a repository
 - Added "snapcraft.io", "charmhub.io", "netplan.io" to a list of projects to be fetched
 - "canonical.design" is temporarily commented out in the list of projects, since the [repository's](https://github.com/canonical/canonical-design) name is not correct at the moment. As soon as it's fixed, we will uncomment it as well.

## QA

### QA steps

- Check out this repo
 - Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis

dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

In another terminal, run 
```bash
yarn dev
```

- Access the application on localhost:8104/app
- Wait for the projects to load
- Click around the app and make sure everything works as expected
- After projects have been loaded, check that "snapcraft.io", "charmhub.io" and "netplan.io" are in the list and have webpages inside.

## Fixes

 - Fixes https://warthogs.atlassian.net/browse/WD-23891

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
