### PR TITLE
[WD-24286] feat: Render paginated assets on a web page

### DIFF
--- a/static/client/App.scss
+++ b/static/client/App.scss
@@ -68,8 +68,8 @@
     position: sticky !important;
     top: -1.5rem;
     z-index: 9;
-  
-    & button[aria-expanded="true"]{
+
+    & button[aria-expanded="true"] {
       background: var(--vf-color-background-neutral-hover) !important;
     }
   }
@@ -78,6 +78,10 @@
   }
 }
 
-.p-table__row--highlight{
+.p-table__row--highlight {
   background: var(--vf-color-background-neutral-hover) !important;
+}
+
+.p-asset__image {
+  background: $color-mid-x-light;
 }

--- a/static/client/components/Views/TableView/ProjectTitle.tsx
+++ b/static/client/components/Views/TableView/ProjectTitle.tsx
@@ -20,7 +20,10 @@ const ProjectTitle: React.FC<ProjectTitleProps> = ({ project }) => {
       <span className="p-muted-heading" style={{ margin: "0 0.5rem" }}>
         {project.name}
       </span>
-      <Badge className="u-no-padding--top" value={countPages(project.templates) - (isFilterApplied ? 1 : 0)} />
+      <Badge
+        className="u-no-padding--top u-no-margin--bottom"
+        value={countPages(project.templates) - (isFilterApplied ? 1 : 0)}
+      />
     </span>
   );
 };

--- a/static/client/components/WebpageAssets/Asset.tsx
+++ b/static/client/components/WebpageAssets/Asset.tsx
@@ -14,7 +14,7 @@ const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
 
   return (
     <>
-      <div className="p-image-container--3-2 is-highlighted">
+      <div className="p-image-container--3-2 p-asset__image">
         <img
           alt=""
           className="p-image-container__image"

--- a/static/client/components/WebpageAssets/Asset.tsx
+++ b/static/client/components/WebpageAssets/Asset.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo } from "react";
+
+import type { IAsset } from "@/services/api/types/assets";
+
+const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
+  const assetName = useMemo(() => {
+    return asset.url.split("/v1/")[1];
+  }, [asset.url]);
+
+  return (
+    <>
+      <div className="p-image-container--3-2">
+        <img alt="" className="p-image-container__image" src={asset.url} />
+      </div>
+      <div className="asset-name">
+        <b>{assetName}</b>
+      </div>
+      <div className="asset-type">
+        <p>
+          File type: <b>{asset.type}</b>
+        </p>
+      </div>
+      <div className="asset-cta">
+        <div className="p-cta-block">
+          <a
+            className="p-button--positive"
+            href={`https://assets.ubuntu.com/manager/details?file-path=${assetName}`}
+            rel="noreferrer"
+            target="_blank"
+          >
+            View
+          </a>
+          <a
+            className="p-button"
+            href={`https://assets.ubuntu.com/manager/update?file-path=${assetName}`}
+            rel="noreferrer"
+            target="_blank"
+          >
+            Edit
+          </a>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Asset;

--- a/static/client/components/WebpageAssets/Asset.tsx
+++ b/static/client/components/WebpageAssets/Asset.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 
+import config from "@/config";
 import type { IAsset } from "@/services/api/types/assets";
 
 const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
@@ -7,12 +8,20 @@ const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
     return asset.url.split("/v1/")[1];
   }, [asset.url]);
 
+  const isImgFile = useMemo(() => {
+    return [".jpg", ".jpeg", ".png", ".gif", ".svg"].includes(asset.type.toLowerCase());
+  }, [asset.type]);
+
   return (
     <>
-      <div className="p-image-container--3-2">
-        <img alt="" className="p-image-container__image" src={asset.url} />
+      <div className="p-image-container--3-2 is-highlighted">
+        <img
+          alt=""
+          className="p-image-container__image"
+          src={isImgFile ? asset.url : "https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg"}
+        />
       </div>
-      <div className="asset-name">
+      <div className="asset-name u-truncate">
         <b>{assetName}</b>
       </div>
       <div className="asset-type">
@@ -24,7 +33,7 @@ const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
         <div className="p-cta-block">
           <a
             className="p-button--positive"
-            href={`https://assets.ubuntu.com/manager/details?file-path=${assetName}`}
+            href={`${config.assetsManagerUrl}/details?file-path=${assetName}`}
             rel="noreferrer"
             target="_blank"
           >
@@ -32,7 +41,7 @@ const Asset: React.FC<{ asset: IAsset }> = ({ asset }) => {
           </a>
           <a
             className="p-button"
-            href={`https://assets.ubuntu.com/manager/update?file-path=${assetName}`}
+            href={`${config.assetsManagerUrl}/update?file-path=${assetName}`}
             rel="noreferrer"
             target="_blank"
           >

--- a/static/client/components/WebpageAssets/index.tsx
+++ b/static/client/components/WebpageAssets/index.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback, useState } from "react";
+
+import { Pagination, Spinner } from "@canonical/react-components";
+
+import Asset from "./Asset";
+
+import { useWebpageAssets } from "@/services/api/hooks/assets";
+import type { IPage } from "@/services/api/types/pages";
+
+const WebpageAssets: React.FC<{ page: IPage }> = ({ page }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const { data: assetsData, isLoading } = useWebpageAssets(page.url ?? "", page.project?.name ?? "", currentPage, 12);
+
+  const paginate = useCallback((pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  }, []);
+
+  if (isLoading) return <Spinner text="Loading assets ..." />;
+  if (!assetsData?.assets?.length) return <></>;
+
+  return (
+    <div id="webpage-assets">
+      <section className="p-section">
+        <p className="p-text--small-caps u-sv1">Assets used: {assetsData.total}</p>
+        <div className="grid-row--25-25-25-25">
+          {assetsData.assets?.map((asset) => {
+            return (
+              <div className="grid-col" key={asset.id}>
+                <div className="p-section--shallow">
+                  <Asset asset={asset} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+      <Pagination
+        centered
+        currentPage={assetsData.page}
+        itemsPerPage={assetsData.page_size}
+        paginate={paginate}
+        totalItems={assetsData.total}
+      />
+    </div>
+  );
+};
+
+export default WebpageAssets;

--- a/static/client/components/WebpageAssets/index.tsx
+++ b/static/client/components/WebpageAssets/index.tsx
@@ -13,10 +13,14 @@ const WebpageAssets: React.FC<{ page: IPage }> = ({ page }) => {
 
   const paginate = useCallback((pageNumber: number) => {
     setCurrentPage(pageNumber);
+    document.querySelector("#webpage-assets")?.scrollIntoView({
+      block: "start",
+      behavior: "smooth",
+    });
   }, []);
 
   if (isLoading) return <Spinner text="Loading assets ..." />;
-  if (!assetsData?.assets?.length) return <></>;
+  if (!assetsData?.assets?.length) return null;
 
   return (
     <div id="webpage-assets">

--- a/static/client/components/WebpageAssets/index.tsx
+++ b/static/client/components/WebpageAssets/index.tsx
@@ -37,14 +37,14 @@ const WebpageAssets: React.FC<{ page: IPage }> = ({ page }) => {
             );
           })}
         </div>
+        <Pagination
+          centered
+          currentPage={assetsData.page}
+          itemsPerPage={assetsData.page_size}
+          paginate={paginate}
+          totalItems={assetsData.total}
+        />
       </section>
-      <Pagination
-        centered
-        currentPage={assetsData.page}
-        itemsPerPage={assetsData.page_size}
-        paginate={paginate}
-        totalItems={assetsData.total}
-      />
     </div>
   );
 };

--- a/static/client/config/index.ts
+++ b/static/client/config/index.ts
@@ -31,6 +31,7 @@ const config = {
     ],
     pageRefreshes: ["Changing or adding to the page layout", "Modifications that change the layout"],
   },
+  assetsManagerUrl: "https://assets.ubuntu.com/manager",
   api: {
     path: "/",
     FETCH_OPTIONS: {

--- a/static/client/pages/Webpage/Webpage.tsx
+++ b/static/client/pages/Webpage/Webpage.tsx
@@ -9,6 +9,7 @@ import JiraTasks from "@/components/JiraTasks";
 import OwnerAndReviewers from "@/components/OwnerAndReviewers";
 import Products from "@/components/Products";
 import RequestTaskModal from "@/components/RequestTaskModal";
+import WebpageAssets from "@/components/WebpageAssets";
 import config from "@/config";
 import { ChangeRequestType, PageStatus } from "@/services/api/types/pages";
 
@@ -135,6 +136,7 @@ const Webpage = ({ page, project }: IWebpageProps): ReactNode => {
           <JiraTasks tasks={page.jira_tasks} />
         </div>
       ) : null}
+      <WebpageAssets page={page} />
       {modalOpen && (
         <RequestTaskModal
           changeType={changeType}

--- a/static/client/services/api/constants.ts
+++ b/static/client/services/api/constants.ts
@@ -9,6 +9,7 @@ export const ENDPOINTS = {
   currentUser: "/api/current-user",
   getProducts: "/api/get-products",
   setProducts: "/api/set-product",
+  getWebpageAssets: "/api/get-webpage-assets",
 };
 
 export const REST_TYPES = {

--- a/static/client/services/api/hooks/assets.ts
+++ b/static/client/services/api/hooks/assets.ts
@@ -9,11 +9,13 @@ export function useWebpageAssets(
   projectName: string,
   page: number = 1,
   perPage: number = 12,
-): IUseQueryHookRest<IAssetsResponse> {
-  const result = useQuery<IAssetsResponse, IApiBasicError>({
+): IUseQueryHookRest<IAssetsResponse["data"]> {
+  const result = useQuery<IAssetsResponse["data"], IApiBasicError>({
     queryKey: ["webpageAssets", pageUrl, projectName, page, perPage],
     queryFn: () =>
-      PagesServices.getWebpageAssets({ pageUrl, projectName, page, perPage }).then((response: any) => response.data),
+      PagesServices.getWebpageAssets({ pageUrl, projectName, page, perPage }).then(
+        (response: IAssetsResponse) => response.data,
+      ),
   });
 
   const error = result.error;

--- a/static/client/services/api/hooks/assets.ts
+++ b/static/client/services/api/hooks/assets.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "react-query";
+
+import { PagesServices } from "@/services/api/services/pages";
+import type { IAssetsResponse } from "@/services/api/types/assets";
+import type { IApiBasicError, IUseQueryHookRest } from "@/services/api/types/query";
+
+export function useWebpageAssets(
+  pageUrl: string,
+  projectName: string,
+  page: number = 1,
+  perPage: number = 12,
+): IUseQueryHookRest<IAssetsResponse> {
+  const result = useQuery<IAssetsResponse, IApiBasicError>({
+    queryKey: ["webpageAssets", pageUrl, projectName, page, perPage],
+    queryFn: () =>
+      PagesServices.getWebpageAssets({ pageUrl, projectName, page, perPage }).then((response: any) => response.data),
+  });
+
+  const error = result.error;
+  const data = result.data;
+  const isLoading = result.isFetching || result.isLoading;
+
+  return { data, error, isLoading };
+}

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -1,6 +1,7 @@
 import { BasicApiClass } from "./BasicApiClass";
 
 import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
+import type { IGetWebpageAssets } from "@/services/api/types/assets";
 import type {
   INewPage,
   INewPageResponse,
@@ -44,5 +45,12 @@ export class PagesApiClass extends BasicApiClass {
 
   public setProducts(body: ISetProducts) {
     return this.callApi(ENDPOINTS.setProducts, REST_TYPES.POST, body);
+  }
+
+  public getWebpageAssets(body: IGetWebpageAssets) {
+    return this.callApi(`${ENDPOINTS.getWebpageAssets}?page=${body.page}&per_page=${body.perPage}`, REST_TYPES.POST, {
+      webpage_url: body.pageUrl,
+      project_name: body.projectName,
+    });
   }
 }

--- a/static/client/services/api/partials/PagesApiClass.ts
+++ b/static/client/services/api/partials/PagesApiClass.ts
@@ -1,7 +1,7 @@
 import { BasicApiClass } from "./BasicApiClass";
 
 import { ENDPOINTS, REST_TYPES } from "@/services/api/constants";
-import type { IGetWebpageAssets } from "@/services/api/types/assets";
+import type { IAssetsResponse, IGetWebpageAssets } from "@/services/api/types/assets";
 import type {
   INewPage,
   INewPageResponse,
@@ -47,7 +47,7 @@ export class PagesApiClass extends BasicApiClass {
     return this.callApi(ENDPOINTS.setProducts, REST_TYPES.POST, body);
   }
 
-  public getWebpageAssets(body: IGetWebpageAssets) {
+  public getWebpageAssets(body: IGetWebpageAssets): Promise<IAssetsResponse> {
     return this.callApi(`${ENDPOINTS.getWebpageAssets}?page=${body.page}&per_page=${body.perPage}`, REST_TYPES.POST, {
       webpage_url: body.pageUrl,
       project_name: body.projectName,

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -1,4 +1,5 @@
 import { api } from "@/services/api";
+import type { IGetWebpageAssets } from "@/services/api/types/assets";
 import type {
   INewPage,
   INewPageResponse,
@@ -35,6 +36,10 @@ export const requestRemoval = async (body: IRequestRemoval): Promise<void> => {
 
 export const setProducts = async (body: ISetProducts) => {
   return api.pages.setProducts(body);
+};
+
+export const getWebpageAssets = async (body: IGetWebpageAssets) => {
+  return api.pages.getWebpageAssets(body);
 };
 
 export * as PagesServices from "./pages";

--- a/static/client/services/api/services/pages.ts
+++ b/static/client/services/api/services/pages.ts
@@ -1,5 +1,5 @@
 import { api } from "@/services/api";
-import type { IGetWebpageAssets } from "@/services/api/types/assets";
+import type { IAssetsResponse, IGetWebpageAssets } from "@/services/api/types/assets";
 import type {
   INewPage,
   INewPageResponse,
@@ -38,7 +38,7 @@ export const setProducts = async (body: ISetProducts) => {
   return api.pages.setProducts(body);
 };
 
-export const getWebpageAssets = async (body: IGetWebpageAssets) => {
+export const getWebpageAssets = async (body: IGetWebpageAssets): Promise<IAssetsResponse> => {
   return api.pages.getWebpageAssets(body);
 };
 

--- a/static/client/services/api/types/assets.ts
+++ b/static/client/services/api/types/assets.ts
@@ -1,0 +1,20 @@
+export interface IAsset {
+  id: number;
+  url: string;
+  type: string;
+}
+
+export interface IAssetsResponse {
+  assets: IAsset[];
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}
+
+export interface IGetWebpageAssets {
+  pageUrl: string;
+  projectName: string;
+  page?: number;
+  perPage?: number;
+}

--- a/static/client/services/api/types/assets.ts
+++ b/static/client/services/api/types/assets.ts
@@ -5,11 +5,13 @@ export interface IAsset {
 }
 
 export interface IAssetsResponse {
-  assets: IAsset[];
-  page: number;
-  page_size: number;
-  total: number;
-  total_pages: number;
+  data: {
+    assets: IAsset[];
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
 }
 
 export interface IGetWebpageAssets {

--- a/webapp/routes/webpage.py
+++ b/webapp/routes/webpage.py
@@ -37,6 +37,7 @@ def get_webpage_assets(body: GetWebpageAssetsModel):
         .join(WebpageAsset, WebpageAsset.asset_id == Asset.id)
         .filter(WebpageAsset.webpage_id == webpage.id)
         .order_by(Asset.id)  # Optional, but good for consistent pagination
+        .distinct()  # If join might cause duplicate Asset rows
     )
 
     total = query.count()

--- a/webapp/routes/webpage.py
+++ b/webapp/routes/webpage.py
@@ -1,7 +1,7 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from flask_pydantic import validate
 
-from webapp.models import Project, Webpage
+from webapp.models import Asset, Project, Webpage, WebpageAsset, db
 from webapp.schemas import GetWebpageAssetsModel
 from webapp.sso import login_required
 
@@ -22,15 +22,35 @@ def get_webpage_assets(body: GetWebpageAssetsModel):
         return jsonify({"error": "Project not found"}), 404
 
     webpage = Webpage.query.filter_by(
-        url=webpage_url, project_id=project.id
+        url=webpage_url,
+        project_id=project.id
     ).first()
 
     if not webpage:
         return jsonify({"error": "Webpage not found"}), 404
 
-    webpage_assets = webpage.assets
+    page = request.values.get("page", type=int, default=1)
+    per_page = request.values.get("per_page", type=int, default=12)
+
+    query = (
+        db.session.query(Asset)
+        .join(WebpageAsset, WebpageAsset.asset_id == Asset.id)
+        .filter(WebpageAsset.webpage_id == webpage.id)
+        .order_by(Asset.id)  # Optional, but good for consistent pagination
+    )
+
+    total = query.count()
+    assets = query.offset((page - 1) * per_page).limit(per_page).all()
 
     return (
-        jsonify({"assets": [asset.to_dict() for asset in webpage_assets]}),
+        jsonify(
+            {
+                "assets": [asset.to_dict() for asset in assets],
+                "page": page,
+                "page_size": per_page,
+                "total": total,
+                "total_pages": (total + per_page - 1) // per_page,
+            }
+        ),
         200,
     )

--- a/webapp/scheduled_tasks.py
+++ b/webapp/scheduled_tasks.py
@@ -138,7 +138,7 @@ def parse_webpage_assets() -> None:
                 with open(file_path, "r") as f:
                     for line in f:
                         match = re.search(
-                            r"https?://assets\.ubuntu\.com\/[^\s\"'()<>\?]+",
+                            r"https?://assets\.ubuntu\.com\/[^\"'()<>\?]+",
                             line,
                         )
                         if match:


### PR DESCRIPTION
## Done

 - Added pagination to `/api/get-webpage-assets` endpoint
 - Render paginated assets in a grid on a webpage

## QA

### QA steps


- Check out this repo
 - Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis

dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

In another terminal, run 
```bash
yarn dev
```

- Access the application on localhost:8104/app
- Wait for the projects to load, and assets to parse
- Open any webpage which is expected to have assets
- It should show all the assets, on that webpage
- Click around pagination to verify pagination works
- Clicking on "View" button should take you to asset's details page on assets manager
- Clicking on "Edit" button should take you to asset"s update page on assets manager

## Fixes

 - Fixes [WD-24286](https://warthogs.atlassian.net/browse/WD-24286)

## Screenshots
<img width="1920" height="1080" alt="Screenshot from 2025-08-19 12-16-56" src="https://github.com/user-attachments/assets/94d26542-e96e-4ffe-9981-dd765ca1d174" />
<img width="1920" height="1080" alt="Screenshot from 2025-08-19 12-17-03" src="https://github.com/user-attachments/assets/f4583acd-6917-4116-9d53-caf97b50403b" />
<img width="1920" height="1080" alt="Screenshot from 2025-08-19 12-17-29" src="https://github.com/user-attachments/assets/de568a8a-a7d1-45cb-a3eb-a2d2e305acf7" />




[WD-24286]: https://warthogs.atlassian.net/browse/WD-24286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ