### PR TITLE
feat: stage git binary

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,6 +18,8 @@ parts:
   flask-framework/install-app:
     stage-packages:
       - git
+    stage:
+      - usr/bin/git
     prime:
       - flask/app/.env
       - flask/app/app.py


### PR DESCRIPTION
## Problem
The git binary is not currently accessible in the charm.

## Done

 - Added binary path from staging environment

## QA

 - Check that deployments to staging and production work as expected

## Fixes

 - Fixes [WD-XXX](https://warthogs.atlassian.net/browse/WD-XXX)
