### PR TITLE
[WD-26091] feat: Assign user|admin role based on launchpad team membership, upon SSO login

### DIFF
--- a/migrations/versions/14729444f282_.py
+++ b/migrations/versions/14729444f282_.py
@@ -1,0 +1,25 @@
+"""Added role column to users table
+
+Revision ID: 14729444f282
+Revises: 1b6109065dba
+Create Date: 2025-08-26 17:15:11.023451
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "14729444f282"
+down_revision = "1b6109065dba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("role", sa.String(), default="user"))
+
+
+def downgrade():
+    op.drop_column("users", "role")

--- a/static/client/components/Navigation/Navigation.tsx
+++ b/static/client/components/Navigation/Navigation.tsx
@@ -144,6 +144,8 @@ const Navigation = (): ReactNode => {
               </div>
               <div className="p-text--small u-text--muted u-truncate p-side-navigation__label">
                 <span>{user?.email}</span>
+                <br />
+                <span>Role: {user?.role?.toUpperCase()}</span>
               </div>
               <hr className="p-rule" />
               <Button appearance="base" className="p-side-navigation__link" onClick={logout}>

--- a/static/client/services/api/types/users.ts
+++ b/static/client/services/api/types/users.ts
@@ -5,6 +5,7 @@ export interface IUser {
   jobTitle: string;
   department: string;
   team: string;
+  role: string;
 }
 
 export interface IUsersResponse {

--- a/webapp/helper.py
+++ b/webapp/helper.py
@@ -27,6 +27,7 @@ def get_or_create_user_id(user):
             department=user.get("department"),
             job_title=user.get("jobTitle"),
             hrc_id=user.get("id"),
+            role=user.get("role"),
         )
 
     return user_exists.id

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -134,6 +134,7 @@ class User(db.Model, DateTimeMixin):
     department: str = Column(String)
     hrc_id: int = Column(Integer)
     job_title: str = Column(String)
+    role: str = Column(String)
 
     webpages = relationship("Webpage", back_populates="owner")
     reviewers = relationship("Reviewer", back_populates="user")

--- a/webapp/routes/user.py
+++ b/webapp/routes/user.py
@@ -11,7 +11,7 @@ from webapp.models import (
     get_or_create,
 )
 from webapp.site_repository import SiteRepository
-from webapp.sso import login_required
+from webapp.sso import is_admin, login_required
 
 DISABLE_SSO = os.environ.get("DISABLE_SSO") or os.environ.get(
     "FLASK_DISABLE_SSO"
@@ -112,7 +112,18 @@ def current_user():
                 "team": user.team,
                 "department": user.department,
                 "jobTitle": user.job_title,
+                "role": user.role,
             }
         ),
+        200,
+    )
+
+# For QA only, to be removed before merging
+@user_blueprint.route("/check_admin", methods=["GET"])
+@login_required
+@is_admin
+def checkAdmin():
+    return (
+        jsonify({"message": "You are an admin"}),
         200,
     )

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -6,16 +6,19 @@ from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
 
 from webapp.helper import get_or_create_user_id, get_user_from_directory_by_key
-from webapp.models import User
+from webapp.models import User, db
 
 SSO_LOGIN_URL = "https://login.ubuntu.com"
 # private teams like canonical are not returned in response atm
 # so temporarily need to add multiple subset public teams
+
+SSO_ADMIN_TEAM = "content-system-admins"
 SSO_TEAM = (
     "canonical",
     "canonical-content-people",
     "pga-admins",
     "canonical-webmonkeys",
+    SSO_ADMIN_TEAM,
 )
 DISABLE_SSO = os.environ.get("DISABLE_SSO") or os.environ.get(
     "FLASK_DISABLE_SSO"
@@ -45,20 +48,32 @@ def init_sso(app: flask.Flask):
         if not (set(SSO_TEAM) & set(resp.extensions["lp"].is_member)):
             flask.abort(403)
 
+        # check if user is admin
+        role = (
+            "admin"
+            if SSO_ADMIN_TEAM in resp.extensions["lp"].is_member
+            else "user"
+        )
+
         # find the user in database
         user = User.query.filter_by(email=resp.email).first()
+        if user and user.role != role:
+            user.role = role
+            db.session.commit()
         if not user:
             # fetch user record from directory
             response = get_user_from_directory_by_key("email", resp.email)
 
             if response.status_code == 200:
                 user = response.json().get("data", {}).get("employees", [])[0]
+                user["role"] = role
                 # save user in users table
                 get_or_create_user_id(user)
 
         flask.session["openid"] = {
             "identity_url": resp.identity_url,
             "email": resp.email,
+            "role": role,
         }
 
         return flask.redirect(open_id.get_next_url())
@@ -101,3 +116,26 @@ def login_required(func):
         return flask.redirect("/login_page?next=" + flask.request.path)
 
     return is_user_logged_in
+
+
+def is_admin(func):
+    """
+    Decorator that checks if a user is an admin user
+    """
+
+    @functools.wraps(func)
+    def is_admin_user(*args, **kwargs):
+        if (
+            "openid" in flask.session
+            and flask.session.get("openid")["role"] == "admin"
+        ):
+            return func(*args, **kwargs)
+
+        return (
+            flask.jsonify(
+                {"error": "This operation requires admin privileges"}
+            ),
+            403,
+        )
+
+    return is_admin_user


### PR DESCRIPTION
## Done

 - Added user|admin roles
 - Added `is_admin` decorator that can be used on any request to restrict access to admins

## QA

### QA steps

- Check out this repo
 - Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis

dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```

In another terminal, run 
```bash
yarn dev
```

- Visit the application on localhost:8104/login_page
- Cick on 'Login with U1' button
- You should see "content-system-admins" team if you are a member of that team on launchpad

<img width="1879" height="992" alt="image" src="https://github.com/user-attachments/assets/28a0f48d-ee16-4438-aab5-5ba2bd2357da" />

- Login with the admin team
- You should see the something like this in the bottom left sidebar

<img width="403" height="183" alt="image" src="https://github.com/user-attachments/assets/88d03307-e688-4e84-bef5-42f47c7bb41c" />

- Visit http://localhost:8104/api/check_admin in the browser
- You should see the following response

<img width="374" height="96" alt="image" src="https://github.com/user-attachments/assets/bd9b9c9b-ffa8-44c9-a057-122d4917de67" />





## Fixes

 - Fixes [WD-26091](https://warthogs.atlassian.net/browse/WD-26091)
