### PR TITLE
feat: add engine pool options

### DIFF
--- a/webapp/models.py
+++ b/webapp/models.py
@@ -242,7 +242,13 @@ class WebpageAsset(db.Model, DateTimeMixin):
 
 
 def init_db(app: Flask):
-    engine = create_engine(app.config["SQLALCHEMY_DATABASE_URI"])
+    engine = create_engine(
+        app.config["SQLALCHEMY_DATABASE_URI"],
+        pool_timeout=30,
+        pool_recycle=3600,
+        pool_size=10,
+        pool_pre_ping=True,
+    )
     session_factory = sessionmaker(bind=engine)
 
     db.init_app(app)


### PR DESCRIPTION
## Problem
The application occasionally consumes all available database connections, especially when starting up. There is already some default pooling present in sqlalchemy, but it seems we now need to finetune this behaviour and control the number of connections without sacrificing performance.

## Done

 - Added pool options:
   - `pool_timeout=30`: We don't have queries that take a long time, so we should be terminating long running hanging queries that could block others
   - `pool_recycle=3600`: Every 1h, replace connections. This removes connections that have become silently stale, especially when there is low traffic
   - `pool_size=10`: Limit the number of connections to 10. Bear in mind that there is a default `max_overflow` of 10 as well, so each deployed instance of the application will _at most_ make 20 connection requests.
We currently have 3 deployed pods on production, and with this change we can support up to 5 pods simultaneously (100 connections max) with minimal performance downgrades.
   - `pool_pre_ping=True`: Make a small SQL statement before every transaction, to determine if the connection from the pool is active. This prevents the app from making queries on stale connections.

## QA

- Check out this repo
- Run the project
```bash
docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres
docker run -d -p 6379:6379 redis
dotrun
```

In a different terminal, run
```bash
dotrun exec celery -A webapp.app.celery_app worker -B  --loglevel=DEBUG
```
In another terminal, run
```
yarn dev
```

Visit the application at http://localhost:8104/app

## Fixes

 - Fixes [WD-26528](https://warthogs.atlassian.net/browse/WD-26528)

