### PR TITLE
fix: exclude directories not having valid content pages or children

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ line-length = 79
 exclude = ["charm"]
 
 [tool.ruff.lint]
+# Pin the rule set explicitly, Ruff >= 0.14 widened its implicit defaults.
+select = ["E4", "E7", "E9", "F"]
+
 # Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
 # overlap with the use of a formatter, like Black, but we can override this behavior by
 # explicitly adding the rule.

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -314,8 +314,7 @@ def has_page(node):
         return True
 
     return any(
-        child["ext"] == ".dir"
-        or not is_contact_page(Path(child["file_path"]))
+        child["ext"] == ".dir" or not is_contact_page(Path(child["file_path"]))
         for child in node["children"]
     )
 

--- a/webapp/parse_tree.py
+++ b/webapp/parse_tree.py
@@ -297,6 +297,29 @@ def update_tags(tags, new_tags):
     return tags
 
 
+def is_contact_page(path):
+    """Return True if the file is a contact form e.g contact-us.html"""
+    return path.stem == "contact" or path.stem.startswith("contact-")
+
+
+def has_page(node):
+    """
+    Return True if the directory node holds a valid page of its own (an index
+    page), or is a parent of a directory or page that does.
+
+    Contact forms do not qualify a directory on their own, as they are not
+    sections of the site, so a directory that only holds one is dropped.
+    """
+    if node["ext"] in (".html", ".md"):
+        return True
+
+    return any(
+        child["ext"] == ".dir"
+        or not is_contact_page(Path(child["file_path"]))
+        for child in node["children"]
+    )
+
+
 def create_node():
     """Return a fresh copy of a node from a template"""
     return {
@@ -377,7 +400,7 @@ def scan_directory(path_name, base=None):
         # If the child is a directory, scan it
         if child.is_dir():
             child_node = scan_directory(str(child), base=base)
-            if child_node.get("title") or child_node.get("children"):
+            if has_page(child_node):
                 node["children"].append(child_node)
 
     return node


### PR DESCRIPTION
## Done

 - Added checks to see if a directory is non-empty

## QA

### QA steps

 - Checkout this pull request and run the project with `task`
 - Once project is up and running,  access the application on localhost:8104/app
 - Search for `canonical.com/solutions/networking` and verify it doesn't show up

## Fixes

 - Fixes [WD-38504](https://warthogs.atlassian.net/browse/WD-38504)


[WD-38504]: https://warthogs.atlassian.net/browse/WD-38504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ